### PR TITLE
Correct generated id for link element

### DIFF
--- a/src/Resources/views/Admin/Feed/show.html.twig
+++ b/src/Resources/views/Admin/Feed/show.html.twig
@@ -42,14 +42,14 @@
                                 <div class="ui icon input" style="width: 100%;position: relative;">
                                     <div class="ui pointing below label teal"
                                          style="position:absolute; right: 10px; top: -100%; display: none"
-                                         id="link-copied-{{ loop.index }}">
+                                         id="link-copied-{{ loop.parent.loop.index }}">
                                         <i class="check icon"></i> {{ 'setono_sylius_feed.ui.link_copied'|trans }}
                                     </div>
-                                    <input id="link-{{ loop.index }}" type="text"
+                                    <input id="link-{{ loop.parent.loop.index }}" type="text"
                                            value="{{ setono_sylius_feed_generate_feed_url(feed, channel, locale) }}"
                                            readonly>
-                                    <i class="copy link icon" data-link-id="link-{{ loop.index }}"
-                                       data-link-copied-id="link-copied-{{ loop.index }}"
+                                    <i class="copy link icon" data-link-id="link-{{ loop.parent.loop.index }}"
+                                       data-link-copied-id="link-copied-{{ loop.parent.loop.index }}"
                                        data-content="{{ 'setono_sylius_feed.ui.click_to_copy'|trans }}"
                                        data-position="top right"></i>
                                 </div>


### PR DESCRIPTION
The generated id for link element was in the channels same. Channel A has link element with id link-1 and channel B has a link element with id link-1. Copy button was always copied value from the first element with id link-1.

Now should the generated id for link element different for each channel. Channel A should have link element with id link-1 and channel B should have link element with id link-2. Copy button should copied the right value for each link element.