### PR TITLE
Allow identifier_exists to be populated with false

### DIFF
--- a/src/Resources/views/Feed/Google/Shopping/_item.txt.twig
+++ b/src/Resources/views/Feed/Google/Shopping/_item.txt.twig
@@ -17,7 +17,7 @@
     <g:brand>{{ item.brand|e }}</g:brand>
     <g:gtin>{{ item.gtin|e }}</g:gtin>
     <g:mpn>{{ item.mpn|e }}</g:mpn>
-    <g:identifier_exists>{{ item.identifierExists|e }}</g:identifier_exists>
+    {% if not item.identifierExists %}<g:identifier_exists>false</g:identifier_exists>{% endif %}
     <g:condition>{{ item.condition|e }}</g:condition>
     <g:item_group_id>{{ item.itemGroupId|e }}</g:item_group_id>
     <g:google_product_category>{{ item.googleProductCategory|e }}</g:google_product_category>

--- a/tests/Behat/Context/Cli/ProcessFeedsContext.php
+++ b/tests/Behat/Context/Cli/ProcessFeedsContext.php
@@ -125,6 +125,7 @@ final class ProcessFeedsContext implements Context
     <g:image_link>https://example.dk/media/cache/resolve/sylius_shop_product_large_thumbnail/%image_path%</g:image_link>
     <g:availability>instock</g:availability>
     <g:price>0USD</g:price>
+    <g:identifier_exists>false</g:identifier_exists>
     <g:condition>new</g:condition>
     <g:item_group_id>WARM_BEER</g:item_group_id>
 </item>
@@ -147,6 +148,7 @@ CONTENT;
     <g:image_link>https://example.com/media/cache/resolve/sylius_shop_product_large_thumbnail/%image_path%</g:image_link>
     <g:availability>instock</g:availability>
     <g:price>0USD</g:price>
+    <g:identifier_exists>false</g:identifier_exists>
     <g:condition>new</g:condition>
     <g:item_group_id>COLD_BEER</g:item_group_id>
 </item>


### PR DESCRIPTION
Boolean property identifierExists is converted to empty string when false, so that the tag <g:identifier_exists> was always removed and it was impossible to populate it with the "false" value.