### PR TITLE
Fix identifier_exists false

### DIFF
--- a/src/Resources/views/Feed/Google/Shopping/_item.txt.twig
+++ b/src/Resources/views/Feed/Google/Shopping/_item.txt.twig
@@ -17,7 +17,7 @@
     <g:brand>{{ item.brand|e }}</g:brand>
     <g:gtin>{{ item.gtin|e }}</g:gtin>
     <g:mpn>{{ item.mpn|e }}</g:mpn>
-    {% if not item.identifierExists %}<g:identifier_exists>false</g:identifier_exists>{% endif %}
+    {% if item.identifierExists is same as(false) %}<g:identifier_exists>false</g:identifier_exists>{% endif %}
     <g:condition>{{ item.condition|e }}</g:condition>
     <g:item_group_id>{{ item.itemGroupId|e }}</g:item_group_id>
     <g:google_product_category>{{ item.googleProductCategory|e }}</g:google_product_category>

--- a/tests/Behat/Context/Cli/ProcessFeedsContext.php
+++ b/tests/Behat/Context/Cli/ProcessFeedsContext.php
@@ -125,7 +125,6 @@ final class ProcessFeedsContext implements Context
     <g:image_link>https://example.dk/media/cache/resolve/sylius_shop_product_large_thumbnail/%image_path%</g:image_link>
     <g:availability>in_stock</g:availability>
     <g:price>0USD</g:price>
-    <g:identifier_exists>false</g:identifier_exists>
     <g:condition>new</g:condition>
     <g:item_group_id>WARM_BEER</g:item_group_id>
 </item>
@@ -148,7 +147,6 @@ CONTENT;
     <g:image_link>https://example.com/media/cache/resolve/sylius_shop_product_large_thumbnail/%image_path%</g:image_link>
     <g:availability>in_stock</g:availability>
     <g:price>0USD</g:price>
-    <g:identifier_exists>false</g:identifier_exists>
     <g:condition>new</g:condition>
     <g:item_group_id>COLD_BEER</g:item_group_id>
 </item>


### PR DESCRIPTION
With #55 we introduced a bug and BC break. If `identifierExists` is not set on the item (so if it is `null`) the feed should not contain `<g:identifier_exists>false</g:identifier_exists>`. That tag should be present only if `identifierExists` has been explicitly set to false.
But `if not item.identifierExists` will evaluate to true even if `identifierExists` is null.