### PR TITLE
Make brand, size and color attributes translatable

### DIFF
--- a/src/FeedContext/Google/Shopping/ProductItemContext.php
+++ b/src/FeedContext/Google/Shopping/ProductItemContext.php
@@ -17,6 +17,9 @@ use Setono\SyliusFeedPlugin\Model\BrandAwareInterface;
 use Setono\SyliusFeedPlugin\Model\ColorAwareInterface;
 use Setono\SyliusFeedPlugin\Model\ConditionAwareInterface;
 use Setono\SyliusFeedPlugin\Model\GtinAwareInterface;
+use Setono\SyliusFeedPlugin\Model\LocalizedBrandAwareInterface;
+use Setono\SyliusFeedPlugin\Model\LocalizedColorAwareInterface;
+use Setono\SyliusFeedPlugin\Model\LocalizedSizeAwareInterface;
 use Setono\SyliusFeedPlugin\Model\MpnAwareInterface;
 use Setono\SyliusFeedPlugin\Model\SizeAwareInterface;
 use Setono\SyliusFeedPlugin\Model\TaxonPathAwareInterface;
@@ -101,8 +104,12 @@ class ProductItemContext implements ItemContextInterface
                 $data->setProductType($productType);
             }
 
-            if ($variant instanceof BrandAwareInterface && $variant->getBrand() !== null) {
+            if ($variant instanceof LocalizedBrandAwareInterface && $variant->getBrand($locale) !== null) {
+                $data->setBrand((string) $variant->getBrand($locale));
+            } elseif ($variant instanceof BrandAwareInterface && $variant->getBrand() !== null) {
                 $data->setBrand((string) $variant->getBrand());
+            } elseif ($product instanceof LocalizedBrandAwareInterface && $product->getBrand($locale) !== null) {
+                $data->setBrand((string) $product->getBrand($locale));
             } elseif ($product instanceof BrandAwareInterface && $product->getBrand() !== null) {
                 $data->setBrand((string) $product->getBrand());
             }
@@ -119,14 +126,22 @@ class ProductItemContext implements ItemContextInterface
                 $data->setMpn((string) $product->getMpn());
             }
 
-            if ($variant instanceof SizeAwareInterface && $variant->getSize() !== null) {
+            if ($variant instanceof LocalizedSizeAwareInterface && $variant->getSize($locale) !== null) {
+                $data->setSize((string) $variant->getSize($locale));
+            } elseif ($variant instanceof SizeAwareInterface && $variant->getSize() !== null) {
                 $data->setSize((string) $variant->getSize());
+            } elseif ($product instanceof LocalizedSizeAwareInterface && $product->getSize($locale) !== null) {
+                $data->setSize((string) $product->getSize($locale));
             } elseif ($product instanceof SizeAwareInterface && $product->getSize() !== null) {
                 $data->setSize((string) $product->getSize());
             }
 
-            if ($variant instanceof ColorAwareInterface && $variant->getColor() !== null) {
+            if ($variant instanceof LocalizedColorAwareInterface && $variant->getColor($locale) !== null) {
+                $data->setColor((string) $variant->getColor($locale));
+            } elseif ($variant instanceof ColorAwareInterface && $variant->getColor() !== null) {
                 $data->setColor((string) $variant->getColor());
+            } elseif ($product instanceof LocalizedColorAwareInterface && $product->getColor($locale) !== null) {
+                $data->setColor((string) $product->getColor($locale));
             } elseif ($product instanceof ColorAwareInterface && $product->getColor() !== null) {
                 $data->setColor((string) $product->getColor());
             }

--- a/src/Model/BrandAwareInterface.php
+++ b/src/Model/BrandAwareInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\Model;
 
+/**
+ * @deprecated since 0.6.6 This interface is deprecated and will be removed in 0.7.0
+ * Use \Setono\SyliusFeedPlugin\Model\LocalizedBrandAwareInterface instead.
+ */
 interface BrandAwareInterface
 {
     /**

--- a/src/Model/ColorAwareInterface.php
+++ b/src/Model/ColorAwareInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\Model;
 
+/**
+ * @deprecated since 0.6.6 This interface is deprecated and will be removed in 0.7.0
+ * Use \Setono\SyliusFeedPlugin\Model\LocalizedColorAwareInterface instead.
+ */
 interface ColorAwareInterface
 {
     /**

--- a/src/Model/LocalizedBrandAwareInterface.php
+++ b/src/Model/LocalizedBrandAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+
+interface LocalizedBrandAwareInterface
+{
+    /**
+     * Must return a string or an object with __toString implemented
+     *
+     * @return string|object|null
+     */
+    public function getBrand(LocaleInterface $locale);
+}

--- a/src/Model/LocalizedColorAwareInterface.php
+++ b/src/Model/LocalizedColorAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+
+interface LocalizedColorAwareInterface
+{
+    /**
+     * Must return a string or an object with __toString implemented
+     *
+     * @return string|object|null
+     */
+    public function getColor(LocaleInterface $locale);
+}

--- a/src/Model/LocalizedSizeAwareInterface.php
+++ b/src/Model/LocalizedSizeAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+
+interface LocalizedSizeAwareInterface
+{
+    /**
+     * Must return a string or an object with __toString implemented
+     *
+     * @return string|object|null
+     */
+    public function getSize(LocaleInterface $locale);
+}

--- a/src/Model/SizeAwareInterface.php
+++ b/src/Model/SizeAwareInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\Model;
 
+/**
+ * @deprecated since 0.6.6 This interface is deprecated and will be removed in 0.7.0
+ * Use \Setono\SyliusFeedPlugin\Model\LocalizedSizeAwareInterface instead.
+ */
 interface SizeAwareInterface
 {
     /**


### PR DESCRIPTION
Localized interfaces for brand, size and color can be used to translate the attributes values. The old interfaces are still available for backward compatibility, but they have been deprecated. 