### PR TITLE
Use path_name parameter for admin prefix

### DIFF
--- a/src/Resources/config/routing.yaml
+++ b/src/Resources/config/routing.yaml
@@ -6,4 +6,4 @@ shop:
 
 admin:
     resource: "routing/admin.yaml"
-    prefix: /admin
+    prefix: /%sylius_admin.path_name%


### PR DESCRIPTION
Avoid 404s if the admin path is modified via the env variable