### PR TITLE
fix symfony support 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/console": "^5.4 || ^6.3",
         "symfony/dependency-injection": "^5.4 || ^6.3",
         "symfony/event-dispatcher": "^5.4 || ^6.3",
-        "symfony/event-dispatcher-contracts": "^1.1 || ^2.2",
+        "symfony/event-dispatcher-contracts": "^1.1 || ^2.2 || ^3.0",
         "symfony/form": "^5.4 || ^6.3",
         "symfony/http-foundation": "^5.4.7 || ^6.3",
         "symfony/http-kernel": "^5.4 || ^6.3",
@@ -37,7 +37,7 @@
         "symfony/uid": "^5.4 || ^6.3",
         "symfony/validator": "^5.4 || ^6.3",
         "symfony/workflow": "^5.4 || ^6.3",
-        "twig/twig": "^2.14",
+        "twig/twig": "^2.14 || ^3.0",
         "webmozart/assert": "^1.1"
     },
     "require-dev": {

--- a/src/Resources/config/routing.yaml
+++ b/src/Resources/config/routing.yaml
@@ -2,7 +2,7 @@ shop:
     resource: "routing/shop.yaml"
     prefix: /{_locale}
     requirements:
-        _locale: ^[a-z]{2}(?:_[A-Z]{2})?$
+        _locale: ^[A-Za-z]{2,4}(_([A-Za-z]{4}|[0-9]{3}))?(_([A-Za-z]{2}|[0-9]{3}))?$
 
 admin:
     resource: "routing/admin.yaml"

--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -12,17 +12,17 @@ setono_sylius_feed_admin_feed:
             index:
                 icon: 'file image outline'
     type: sylius.resource
-    
+
 setono_sylius_feed_admin_feed_show:
     path: /feeds/{id}
     methods: [GET]
     defaults:
-        _controller: setono_sylius_feed.controller.feed:showAction
+        _controller: setono_sylius_feed.controller.feed::showAction
         _sylius:
             section: admin
             permission: true
             template: "@SetonoSyliusFeedPlugin/Admin/Feed/show.html.twig"
-            
+
 setono_sylius_feed_admin_feed_process:
     path: /feeds/{id}/process
     methods: [GET]
@@ -33,7 +33,7 @@ setono_sylius_feed_admin_feed_violations_index:
     path: /feeds/{id}/violations
     methods: [GET]
     defaults:
-        _controller: setono_sylius_feed.controller.violation:indexAction
+        _controller: setono_sylius_feed.controller.violation::indexAction
         _sylius:
             vars:
                 route:


### PR DESCRIPTION
- adjusting routing to symfonyf 6.3 (use of two colons)
- allow use new version of packages: 
    > `symfony/event-dispatcher-contracts` -> (added: `^3.0`)
    > `twig/twig` -> (added: `^3.0`)