### PR TITLE
New/doctrinepersistence support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -152,6 +152,7 @@ jobs:
                 php-version:
                     - "8.1"
                     - "8.2"
+                    - "8.3"
 
                 dependencies:
                     - "highest"
@@ -159,6 +160,7 @@ jobs:
                 symfony:
                     - "^5.4"
                     - "^6.3"
+                    - "^6.4"
 
         steps:
             -   name: "Checkout"
@@ -192,6 +194,7 @@ jobs:
                 php-version:
                     - "8.1"
                     - "8.2"
+                    - "8.3"
 
                 dependencies:
                     - "highest"
@@ -199,6 +202,7 @@ jobs:
                 symfony:
                     - "^5.4"
                     - "^6.3"
+                    - "^6.4"
 
         steps:
             -   name: "Start MySQL"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "doctrine/collections": "^1.6",
         "doctrine/orm": "^2.7",
-        "doctrine/persistence": "^1.3 || ^2.0",
+        "doctrine/persistence": "^1.3 || ^2.0 || ^3.0",
         "knplabs/knp-menu": "^3.1",
         "league/flysystem": "^1.1 || ^2.1",
         "league/flysystem-bundle": "^1.1 || ^2.4",

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -66,4 +66,8 @@ if (class_exists(Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class)) {
     $bundles[Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class] = ['all' => true];
 }
 
+if (class_exists(Sylius\Abstraction\StateMachine\SyliusStateMachineAbstractionBundle::class)) {
+    $bundles[Sylius\Abstraction\StateMachine\SyliusStateMachineAbstractionBundle::class] = ['all' => true];
+}
+
 return $bundles;

--- a/tests/Application/config/services.yaml
+++ b/tests/Application/config/services.yaml
@@ -2,3 +2,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en_US
+
+services:
+    Psr\Http\Client\ClientInterface:
+        class: GuzzleHttp\Client


### PR DESCRIPTION
Bump doctrine/persistence for Sylius ^1.13 and Symfony 6.4 LTS. Doctrine Persistence is used in 4 files in this bundle.

Static analysis is not working here but does not seems related to the changes.
Same goes with integration tests.