### PR TITLE
Use Workflow interface instead of implementation

### DIFF
--- a/src/Message/Handler/GenerateBatchHandler.php
+++ b/src/Message/Handler/GenerateBatchHandler.php
@@ -40,7 +40,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\Registry;
-use Symfony\Component\Workflow\Workflow;
+use Symfony\Component\Workflow\WorkflowInterface;
 use Throwable;
 use Twig\Environment;
 use Webmozart\Assert\Assert;
@@ -299,7 +299,7 @@ final class GenerateBatchHandler implements MessageHandlerInterface
         $this->urlGenerator->setContext($this->initialRequestContext);
     }
 
-    private function getWorkflow(FeedInterface $feed): Workflow
+    private function getWorkflow(FeedInterface $feed): WorkflowInterface
     {
         try {
             $workflow = $this->workflowRegistry->get($feed, FeedGraph::GRAPH);
@@ -323,7 +323,7 @@ final class GenerateBatchHandler implements MessageHandlerInterface
         return fopen('php://temp', 'w+b');
     }
 
-    private function applyErrorTransition(Workflow $workflow, FeedInterface $feed): void
+    private function applyErrorTransition(WorkflowInterface $workflow, FeedInterface $feed): void
     {
         // if the feed is already errored we won't want to throw an exception
         if ($feed->isErrored()) {


### PR DESCRIPTION
The workflow registry returns `WorkflowInterface` and in SF 6.4 if `APP_DEBUG` is enabled, it uses `Symfony\Component\Workflow\Debug\TraceableWorkflow`. That causes the issue. Using the interface fixes it. 