### PR TITLE
Add backOrder method definition

### DIFF
--- a/src/Feed/Model/Google/Shopping/Availability.php
+++ b/src/Feed/Model/Google/Shopping/Availability.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusFeedPlugin\Feed\Model\Google\Shopping;
 use Spatie\Enum\Enum;
 
 /**
+ * @method static self backOrder()
  * @method static self inStock()
  * @method static self outOfStock()
  * @method static self preOrder()


### PR DESCRIPTION
Without the definition, the value is not recognised by the enum and cannot be used.