### PR TITLE
M5 — Channel breadth + CSV + multi-source + LookupTable enrichment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0 || ^3.0",
         "knplabs/knp-menu": "^3.1",
-        "league/csv": "^9.0",
+        "league/csv": "^9.6",
         "league/flysystem": "^2.1 || ^3.0",
         "league/flysystem-bundle": "^2.4 || ^3.0",
         "liip/imagine-bundle": "^2.4",

--- a/src/Controller/Admin/RefreshLookupTableAction.php
+++ b/src/Controller/Admin/RefreshLookupTableAction.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Controller\Admin;
+
+use Setono\SyliusFeedPlugin\Lookup\LookupTableRefresherInterface;
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Admin "Refresh" action (§10.1): re-imports a LookupTable's rows from its source and redirects back
+ * to the grid with a flash. A failed import keeps the last-good rows (handled by the refresher).
+ */
+final class RefreshLookupTableAction
+{
+    public function __construct(
+        private readonly LookupTableRepositoryInterface $repository,
+        private readonly LookupTableRefresherInterface $refresher,
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    public function __invoke(Request $request, int|string $id): Response
+    {
+        $table = $this->repository->find($id);
+        if (!$table instanceof LookupTableInterface) {
+            throw new NotFoundHttpException(sprintf('There is no lookup table with id "%s"', $id));
+        }
+
+        $this->refresher->refresh($table);
+
+        $session = $request->getSession();
+        if ($session instanceof Session) {
+            $session->getFlashBag()->add('success', 'setono_sylius_feed.lookup_table.refreshed');
+        }
+
+        return new RedirectResponse($this->router->generate('setono_sylius_feed_admin_lookup_table_index'));
+    }
+}

--- a/src/DataSource/ProductDataSource.php
+++ b/src/DataSource/ProductDataSource.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\DataSource;
+
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\Doctrine\ORMTrait;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Doctrine\BatchIterator;
+use Setono\SyliusFeedPlugin\Filter\FilterSet;
+use Sylius\Component\Core\Model\ChannelInterface;
+
+/**
+ * Streams enabled, channel-assigned products — one row per product (§8.7). Iterates in
+ * bounded-memory batches via {@see BatchIterator} (clears the entity manager every batch), so a
+ * large catalog stays within budget even though associations are lazy-loaded per row (§6.3).
+ * Query-pushable filters land in M6; for now only the enabled/channel constraints are applied at
+ * the query level.
+ */
+final class ProductDataSource implements DataSourceInterface
+{
+    use ORMTrait;
+
+    private const BATCH_SIZE = 1000;
+
+    /**
+     * @param class-string $resourceClass
+     */
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly string $resourceClass,
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public function getResourceClass(): string
+    {
+        return $this->resourceClass;
+    }
+
+    public function getItems(FeedContext $context, FilterSet $filters): iterable
+    {
+        return BatchIterator::iterate(
+            $this->createQueryBuilder($context)->getQuery(),
+            $this->getManager($this->resourceClass),
+            self::BATCH_SIZE,
+        );
+    }
+
+    public function count(FeedContext $context, FilterSet $filters): int
+    {
+        return (int) $this->createQueryBuilder($context)
+            ->select('COUNT(product.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function createQueryBuilder(FeedContext $context): QueryBuilder
+    {
+        $queryBuilder = $this->getManager($this->resourceClass)
+            ->getRepository($this->resourceClass)
+            ->createQueryBuilder('product')
+            ->andWhere('product.enabled = true');
+
+        $channel = $context->getChannel();
+        if ($channel instanceof ChannelInterface) {
+            // MEMBER OF (an EXISTS subquery) rather than a join, since Doctrine's toIterable() does
+            // not allow iterating over a query that joins a to-many association.
+            $queryBuilder
+                ->andWhere(':channel MEMBER OF product.channels')
+                ->setParameter('channel', $channel);
+        }
+
+        return $queryBuilder;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\DependencyInjection;
 
 use Setono\SyliusFeedPlugin\Form\Type\FeedType;
+use Setono\SyliusFeedPlugin\Form\Type\LookupTableType;
 use Setono\SyliusFeedPlugin\Model\Feed;
 use Setono\SyliusFeedPlugin\Model\FeedSource;
 use Setono\SyliusFeedPlugin\Model\FeedTranslation;
@@ -125,7 +126,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->defaultValue(LookupTableRepository::class)->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
-                                        ->scalarNode('form')->defaultValue(DefaultResourceType::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('form')->defaultValue(LookupTableType::class)->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,10 @@ use Setono\SyliusFeedPlugin\Form\Type\FeedType;
 use Setono\SyliusFeedPlugin\Model\Feed;
 use Setono\SyliusFeedPlugin\Model\FeedSource;
 use Setono\SyliusFeedPlugin\Model\FeedTranslation;
+use Setono\SyliusFeedPlugin\Model\LookupTable;
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
 use Setono\SyliusFeedPlugin\Repository\FeedRepository;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepository;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType;
@@ -104,6 +107,23 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('interface')->defaultValue(FeedSource::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->defaultValue(EntityRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                        ->scalarNode('form')->defaultValue(DefaultResourceType::class)->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('lookup_table')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(LookupTable::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(LookupTableInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->defaultValue(LookupTableRepository::class)->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                         ->scalarNode('form')->defaultValue(DefaultResourceType::class)->cannotBeEmpty()->end()
                                     ->end()

--- a/src/FeedType/ProductFeedType.php
+++ b/src/FeedType/ProductFeedType.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\FeedType;
+
+use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
+use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
+use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
+use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverRegistryInterface;
+
+/**
+ * One row per Sylius product (§8.7), scoped over channel × locale × currency — a sibling to the
+ * product_variant feed type for destinations that want product-level rows (with a "from" price and
+ * an aggregated availability). Its available source fields are the registered product value
+ * resolvers.
+ */
+final class ProductFeedType implements FeedTypeInterface
+{
+    /**
+     * The source fields this feed type exposes, resolved from the value resolver registry by name.
+     *
+     * @var list<string>
+     */
+    private const FIELDS = [
+        'id',
+        'title',
+        'description',
+        'link',
+        'main_image',
+        'additional_images',
+        'from_price',
+        'product_availability',
+        'variant_count',
+        'is_configurable',
+    ];
+
+    public function __construct(
+        private readonly DataSourceInterface $dataSource,
+        private readonly ValueResolverRegistryInterface $valueResolverRegistry,
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return 'product';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.feed_type.product';
+    }
+
+    public function getDataSource(): DataSourceInterface
+    {
+        return $this->dataSource;
+    }
+
+    public function getScopeDimensions(): array
+    {
+        return [ScopeDimension::CHANNEL, ScopeDimension::LOCALE, ScopeDimension::CURRENCY];
+    }
+
+    public function getAvailableFields(): array
+    {
+        $fields = [];
+
+        foreach (self::FIELDS as $name) {
+            if (!$this->valueResolverRegistry->has($name)) {
+                continue;
+            }
+
+            $resolver = $this->valueResolverRegistry->get($name);
+            $fields[$name] = new FieldDefinition(
+                $name,
+                $resolver->getLabel(),
+                $resolver->getType(),
+                $resolver,
+                'additional_images' === $name,
+            );
+        }
+
+        return $fields;
+    }
+}

--- a/src/Form/Type/LookupTableType.php
+++ b/src/Form/Type/LookupTableType.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Form\Type;
+
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Webmozart\Assert\Assert;
+
+/**
+ * A LookupTable (§10.1): its code/name, the source (`csv`/`url`) + its single location, the
+ * key/join columns and the refresh policy. The location is an unmapped field packed into
+ * `sourceConfig` as `path` (csv) or `url` (url) on submit, and unpacked on edit.
+ */
+final class LookupTableType extends AbstractResourceType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('code', TextType::class, [
+                'label' => 'sylius.ui.code',
+            ])
+            ->add('name', TextType::class, [
+                'required' => false,
+                'label' => 'setono_sylius_feed.form.lookup_table.name',
+            ])
+            ->add('sourceType', ChoiceType::class, [
+                'label' => 'setono_sylius_feed.form.lookup_table.source_type',
+                'choices' => [
+                    'setono_sylius_feed.form.lookup_table.source.csv' => LookupTableInterface::SOURCE_TYPE_CSV,
+                    'setono_sylius_feed.form.lookup_table.source.url' => LookupTableInterface::SOURCE_TYPE_URL,
+                ],
+            ])
+            ->add('location', TextType::class, [
+                'mapped' => false,
+                'required' => false,
+                'label' => 'setono_sylius_feed.form.lookup_table.location',
+                'help' => 'setono_sylius_feed.form.lookup_table.location_help',
+            ])
+            ->add('keyColumn', TextType::class, [
+                'label' => 'setono_sylius_feed.form.lookup_table.key_column',
+            ])
+            ->add('joinField', TextType::class, [
+                'label' => 'setono_sylius_feed.form.lookup_table.join_field',
+            ])
+            ->add('refreshPolicy', ChoiceType::class, [
+                'label' => 'setono_sylius_feed.form.lookup_table.refresh_policy',
+                'choices' => [
+                    'setono_sylius_feed.form.lookup_table.policy.manual' => LookupTableInterface::REFRESH_POLICY_MANUAL,
+                    'setono_sylius_feed.form.lookup_table.policy.before_generate' => LookupTableInterface::REFRESH_POLICY_BEFORE_GENERATE,
+                    'setono_sylius_feed.form.lookup_table.policy.scheduled' => LookupTableInterface::REFRESH_POLICY_SCHEDULED,
+                ],
+            ])
+        ;
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, static function (FormEvent $event): void {
+            $table = $event->getData();
+            if (!$table instanceof LookupTableInterface) {
+                return;
+            }
+
+            $config = $table->getSourceConfig();
+            $location = $config['url'] ?? $config['path'] ?? null;
+            if (is_string($location)) {
+                $event->getForm()->get('location')->setData($location);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, static function (FormEvent $event): void {
+            $table = $event->getData();
+            Assert::isInstanceOf($table, LookupTableInterface::class);
+
+            $location = $event->getForm()->get('location')->getData();
+            if (is_string($location) && '' !== $location) {
+                $key = LookupTableInterface::SOURCE_TYPE_URL === $table->getSourceType() ? 'url' : 'path';
+                $table->setSourceConfig([$key => $location]);
+            }
+        });
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'setono_sylius_feed_lookup_table';
+    }
+}

--- a/src/Format/CsvFormat.php
+++ b/src/Format/CsvFormat.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Format;
+
+use Setono\SyliusFeedPlugin\Writer\CsvWriter;
+use Setono\SyliusFeedPlugin\Writer\CsvWriterConfig;
+use Setono\SyliusFeedPlugin\Writer\WriterConfigInterface;
+
+/**
+ * The generic comma-delimited CSV format (§7): the `csv` writer family with a default
+ * comma/double-quote dialect. Destination-specific CSV dialects (Meta, …) are mapping presets over
+ * this format; the header is the union of the feed's output fields, injected by the generator.
+ */
+final class CsvFormat implements FormatInterface
+{
+    public function getCode(): string
+    {
+        return 'csv';
+    }
+
+    public function getWriter(): string
+    {
+        return CsvWriter::FORMAT;
+    }
+
+    public function getConfig(): WriterConfigInterface
+    {
+        return new CsvWriterConfig();
+    }
+
+    public function getRequiredFields(): array
+    {
+        return [];
+    }
+}

--- a/src/Format/GenericXmlFormat.php
+++ b/src/Format/GenericXmlFormat.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Format;
+
+use Setono\SyliusFeedPlugin\Writer\WriterConfigInterface;
+use Setono\SyliusFeedPlugin\Writer\XmlWriterConfig;
+
+/**
+ * A generic, destination-agnostic XML format (§7): a `feed` root with `item` elements — rendered
+ * by the XML writer. Useful as a starting point for custom destinations that don't match one of
+ * the named presets.
+ */
+final class GenericXmlFormat implements FormatInterface
+{
+    public function getCode(): string
+    {
+        return 'generic_xml';
+    }
+
+    public function getWriter(): string
+    {
+        return 'xml';
+    }
+
+    public function getConfig(): WriterConfigInterface
+    {
+        return new XmlWriterConfig(rootElement: 'feed', itemElement: 'item');
+    }
+
+    public function getRequiredFields(): array
+    {
+        return [];
+    }
+}

--- a/src/Format/PartnerAdsFormat.php
+++ b/src/Format/PartnerAdsFormat.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Format;
+
+use Setono\SyliusFeedPlugin\Writer\WriterConfigInterface;
+use Setono\SyliusFeedPlugin\Writer\XmlWriterConfig;
+
+/**
+ * The Partner-ads product feed format (§7): a `produkter` root with `produkt` item elements —
+ * rendered by the XML writer.
+ */
+final class PartnerAdsFormat implements FormatInterface
+{
+    public function getCode(): string
+    {
+        return 'partner_ads';
+    }
+
+    public function getWriter(): string
+    {
+        return 'xml';
+    }
+
+    public function getConfig(): WriterConfigInterface
+    {
+        return new XmlWriterConfig(rootElement: 'produkter', itemElement: 'produkt');
+    }
+
+    public function getRequiredFields(): array
+    {
+        return [];
+    }
+}

--- a/src/Generator/FeedGenerator.php
+++ b/src/Generator/FeedGenerator.php
@@ -17,6 +17,7 @@ use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface;
+use Setono\SyliusFeedPlugin\Writer\CsvWriterConfig;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -47,6 +48,11 @@ final class FeedGenerator implements FeedGeneratorInterface
         $writer = $this->writerRegistry->get($format->getWriter());
 
         $config = $format->getConfig()->withFeedMetadata($this->buildFeedMetadata($feed, $context));
+        if ($config instanceof CsvWriterConfig) {
+            // CSV needs a single header up front — the union of every source's output fields, so
+            // heterogeneous multi-source rows line up under one header.
+            $config = $config->withHeader($this->unionHeader($feed));
+        }
         $requiredFields = $format->getRequiredFields();
 
         $this->applyRequestContext($context);
@@ -118,6 +124,26 @@ final class FeedGenerator implements FeedGeneratorInterface
         }
 
         return [];
+    }
+
+    /**
+     * The union of every source's output fields, in first-seen order — the CSV header.
+     *
+     * @return list<string>
+     */
+    private function unionHeader(FeedInterface $feed): array
+    {
+        $header = [];
+        foreach ($this->sortedSources($feed) as $source) {
+            foreach ($this->resolveMappings($feed, $source) as $mapping) {
+                $outputField = $mapping->getOutputField();
+                if (!in_array($outputField, $header, true)) {
+                    $header[] = $outputField;
+                }
+            }
+        }
+
+        return $header;
     }
 
     /**

--- a/src/Generator/FieldMappingEvaluator.php
+++ b/src/Generator/FieldMappingEvaluator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\Generator;
 
 use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
 use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
 use Setono\SyliusFeedPlugin\Mapping\SourceType;
 use Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface;
@@ -25,6 +26,7 @@ final class FieldMappingEvaluator implements FieldMappingEvaluatorInterface
         private readonly OperatorRegistryInterface $operatorRegistry,
         private readonly ExpressionEvaluatorInterface $expressionEvaluator,
         private readonly TwigTemplateRendererInterface $twigRenderer,
+        private readonly LookupReferenceResolverInterface $lookupReferenceResolver,
     ) {
     }
 
@@ -32,9 +34,15 @@ final class FieldMappingEvaluator implements FieldMappingEvaluatorInterface
     {
         $entity = $item->getEntity();
         $context = $item->getContext();
-        $item->setSourceResolver(static fn (string $field): mixed => isset($availableFields[$field])
-            ? $availableFields[$field]->getResolver()->resolve($entity, $context)
-            : null);
+        $item->setSourceResolver(function (string $field) use ($entity, $context, $availableFields): mixed {
+            if ($this->lookupReferenceResolver->supports($field)) {
+                return $this->lookupReferenceResolver->resolve($field, $entity, $context, $availableFields);
+            }
+
+            return isset($availableFields[$field])
+                ? $availableFields[$field]->getResolver()->resolve($entity, $context)
+                : null;
+        });
 
         foreach ($mappings as $mapping) {
             if (!$this->conditionSatisfied($mapping, $item)) {

--- a/src/Lookup/CsvLookupSource.php
+++ b/src/Lookup/CsvLookupSource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use League\Csv\Reader;
+use League\Flysystem\FilesystemOperator;
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+
+/**
+ * Imports lookup rows from an uploaded CSV file (§10.1): `sourceConfig.path` is read from the feed
+ * filesystem and parsed with its header row as the column names.
+ */
+final class CsvLookupSource implements LookupSourceInterface
+{
+    public function __construct(private readonly FilesystemOperator $filesystem)
+    {
+    }
+
+    public function getType(): string
+    {
+        return LookupTableInterface::SOURCE_TYPE_CSV;
+    }
+
+    public function fetch(array $sourceConfig): iterable
+    {
+        $path = $sourceConfig['path'] ?? null;
+        if (!is_string($path) || '' === $path) {
+            return;
+        }
+
+        $reader = Reader::createFromStream($this->filesystem->readStream($path));
+        $reader->setHeaderOffset(0);
+
+        foreach ($reader->getRecords() as $record) {
+            yield LookupRow::normalize($record);
+        }
+    }
+}

--- a/src/Lookup/DatabaseLookup.php
+++ b/src/Lookup/DatabaseLookup.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepositoryInterface;
+
+/**
+ * The production {@see LookupInterface}: resolves against admin-managed {@see LookupTableInterface}
+ * resources (§10.1). Each referenced table is loaded once and cached per instance, so a 50k-item
+ * run queries a lookup table a single time rather than per row.
+ */
+final class DatabaseLookup implements LookupInterface
+{
+    /** @var array<string, LookupTableInterface|null> */
+    private array $tables = [];
+
+    public function __construct(private readonly LookupTableRepositoryInterface $repository)
+    {
+    }
+
+    public function get(string $table, mixed $key, string $column): mixed
+    {
+        if (!is_scalar($key)) {
+            return null;
+        }
+
+        return $this->table($table)?->getColumn((string) $key, $column);
+    }
+
+    private function table(string $code): ?LookupTableInterface
+    {
+        if (!array_key_exists($code, $this->tables)) {
+            $this->tables[$code] = $this->repository->findOneByCode($code);
+        }
+
+        return $this->tables[$code];
+    }
+}

--- a/src/Lookup/LookupReferenceResolver.php
+++ b/src/Lookup/LookupReferenceResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepositoryInterface;
+
+/**
+ * @see LookupReferenceResolverInterface
+ */
+final class LookupReferenceResolver implements LookupReferenceResolverInterface
+{
+    private const PREFIX = 'lookup:';
+
+    public function __construct(private readonly LookupTableRepositoryInterface $repository)
+    {
+    }
+
+    public function supports(string $reference): bool
+    {
+        return str_starts_with($reference, self::PREFIX);
+    }
+
+    public function resolve(string $reference, object $entity, FeedContext $context, array $availableFields): mixed
+    {
+        if (!$this->supports($reference)) {
+            return null;
+        }
+
+        $parts = explode(':', substr($reference, strlen(self::PREFIX)), 2);
+        if (2 !== count($parts)) {
+            return null;
+        }
+
+        [$code, $column] = $parts;
+
+        $table = $this->repository->findOneByCode($code);
+        if (null === $table) {
+            return null;
+        }
+
+        $joinField = $table->getJoinField();
+        if (null === $joinField || !isset($availableFields[$joinField])) {
+            return null;
+        }
+
+        $key = $availableFields[$joinField]->getResolver()->resolve($entity, $context);
+        if (!is_scalar($key)) {
+            return null;
+        }
+
+        return $table->getColumn((string) $key, $column);
+    }
+}

--- a/src/Lookup/LookupReferenceResolverInterface.php
+++ b/src/Lookup/LookupReferenceResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
+
+/**
+ * Resolves a `lookup:{code}:{column}` source reference for an item (§10.1): it reads the table's
+ * `joinField` value off the item (via the source resolvers), matches it against the table, and
+ * returns the requested column — so a mapping like `concat(["value", "lookup:badges:badge"])`
+ * enriches each row per item.
+ */
+interface LookupReferenceResolverInterface
+{
+    public function supports(string $reference): bool;
+
+    /**
+     * @param array<string, FieldDefinition> $availableFields
+     */
+    public function resolve(string $reference, object $entity, FeedContext $context, array $availableFields): mixed;
+}

--- a/src/Lookup/LookupRow.php
+++ b/src/Lookup/LookupRow.php
@@ -11,14 +11,20 @@ namespace Setono\SyliusFeedPlugin\Lookup;
 final class LookupRow
 {
     /**
-     * @param iterable<int|string, mixed> $record
-     *
      * @return array<string, scalar|null>
      */
-    public static function normalize(iterable $record): array
+    public static function normalize(mixed $record): array
     {
+        if (!is_iterable($record)) {
+            return [];
+        }
+
         $row = [];
         foreach ($record as $column => $value) {
+            if (!is_scalar($column)) {
+                continue;
+            }
+
             $row[(string) $column] = is_scalar($value) ? $value : null;
         }
 

--- a/src/Lookup/LookupRow.php
+++ b/src/Lookup/LookupRow.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+/**
+ * Normalises a parsed source record into a `column => scalar|null` row (§10.1), string-keying the
+ * columns and dropping non-scalar values.
+ */
+final class LookupRow
+{
+    /**
+     * @param iterable<int|string, mixed> $record
+     *
+     * @return array<string, scalar|null>
+     */
+    public static function normalize(iterable $record): array
+    {
+        $row = [];
+        foreach ($record as $column => $value) {
+            $row[(string) $column] = is_scalar($value) ? $value : null;
+        }
+
+        return $row;
+    }
+}

--- a/src/Lookup/LookupTableRefresher.php
+++ b/src/Lookup/LookupTableRefresher.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Setono\Doctrine\ORMTrait;
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+
+/**
+ * Imports a LookupTable's rows via the source registered for its `sourceType`, keying each row by
+ * its `keyColumn`. On success it stamps `refreshedAt`; on any failure it keeps the last-good rows
+ * and `refreshedAt`, logging a warning — a broken source must not blank out the serving data (§10.1).
+ */
+final class LookupTableRefresher implements LookupTableRefresherInterface
+{
+    use ORMTrait;
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly LookupSourceRegistryInterface $sourceRegistry,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public function refresh(LookupTableInterface $table): void
+    {
+        $sourceType = $table->getSourceType();
+        $keyColumn = $table->getKeyColumn();
+
+        if (null === $sourceType || null === $keyColumn || !$this->sourceRegistry->has($sourceType)) {
+            $this->logger->warning('Cannot refresh lookup table: missing source type/key column or unknown source', [
+                'code' => $table->getCode(),
+            ]);
+
+            return;
+        }
+
+        try {
+            $rows = [];
+            foreach ($this->sourceRegistry->get($sourceType)->fetch($table->getSourceConfig()) as $row) {
+                $key = $row[$keyColumn] ?? null;
+                if (null === $key) {
+                    continue;
+                }
+
+                $rows[(string) $key] = $row;
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('Lookup table refresh failed; keeping the last-good rows', [
+                'code' => $table->getCode(),
+                'exception' => $e,
+            ]);
+
+            return;
+        }
+
+        $table->setRows($rows);
+        $table->setRefreshedAt(new \DateTimeImmutable());
+        $this->getManager($table)->flush();
+    }
+}

--- a/src/Lookup/LookupTableRefresherInterface.php
+++ b/src/Lookup/LookupTableRefresherInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+
+/**
+ * Re-imports a LookupTable's rows from its source (§10.1). A failed refresh keeps the last-good
+ * rows — a transient outage or a malformed download must never blank out the serving data.
+ */
+interface LookupTableRefresherInterface
+{
+    public function refresh(LookupTableInterface $table): void;
+}

--- a/src/Lookup/UrlLookupSource.php
+++ b/src/Lookup/UrlLookupSource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Lookup;
+
+use League\Csv\Reader;
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+
+/**
+ * Imports lookup rows from CSV/TSV at a URL (§10.1). This covers a published-to-web Google Sheet
+ * (its `…/export?format=csv` link is plain CSV — no Google-specific code, no auth). A download
+ * failure throws, so the refresher can keep the last-good rows.
+ */
+final class UrlLookupSource implements LookupSourceInterface
+{
+    public function getType(): string
+    {
+        return LookupTableInterface::SOURCE_TYPE_URL;
+    }
+
+    public function fetch(array $sourceConfig): iterable
+    {
+        $url = $sourceConfig['url'] ?? null;
+        if (!is_string($url) || '' === $url) {
+            return;
+        }
+
+        $content = @file_get_contents($url);
+        if (false === $content) {
+            throw new \RuntimeException(sprintf('Could not download the lookup CSV from "%s"', $url));
+        }
+
+        $reader = Reader::createFromString($content);
+        $reader->setHeaderOffset(0);
+
+        foreach ($reader->getRecords() as $record) {
+            yield LookupRow::normalize($record);
+        }
+    }
+}

--- a/src/MappingPreset/BingMappingPreset.php
+++ b/src/MappingPreset/BingMappingPreset.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\MappingPreset;
+
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
+use Setono\SyliusFeedPlugin\Transformation\StripTags;
+use Setono\SyliusFeedPlugin\Transformation\Truncate;
+
+/**
+ * Seeds a Microsoft (Bing) Shopping product feed (§7): the `google_rss` format plus the default
+ * output→source field mappings for the `product_variant` feed type. Bing consumes the same
+ * `g`-namespaced RSS vocabulary as Google Shopping, so the mapping is identical.
+ */
+final class BingMappingPreset implements MappingPresetInterface
+{
+    public function getCode(): string
+    {
+        return 'bing';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.mapping_preset.bing';
+    }
+
+    public function supports(string $feedType): bool
+    {
+        return 'product_variant' === $feedType;
+    }
+
+    public function getFormat(): string
+    {
+        return 'google_rss';
+    }
+
+    public function getMapping(): array
+    {
+        return [
+            FieldMapping::field('g:id', 'id'),
+            FieldMapping::field('g:item_group_id', 'item_group_id')->onlyIf('is_configurable'),
+            FieldMapping::field('g:title', 'title')->transform(Truncate::chars(150)),
+            FieldMapping::field('g:description', 'description')
+                ->transform(StripTags::all())
+                ->transform(Truncate::chars(5000)),
+            FieldMapping::field('g:link', 'link'),
+            FieldMapping::field('g:image_link', 'main_image'),
+            FieldMapping::field('g:additional_image_link', 'additional_images'),
+            FieldMapping::field('g:availability', 'availability'),
+            FieldMapping::field('g:price', 'channel_price')->transform(MoneyFormat::withCurrency()),
+            FieldMapping::literal('g:condition', 'new'),
+            // Required/expected by Bing but not derivable from core Sylius → flagged for the
+            // admin to complete before the feed can be enabled:
+            FieldMapping::field('g:brand', 'attribute:brand')->requiresInput(),
+            FieldMapping::field('g:gtin', 'attribute:gtin')->requiresInput(),
+            FieldMapping::field('g:google_product_category', 'attribute:google_product_category')->requiresInput(),
+        ];
+    }
+}

--- a/src/MappingPreset/MetaMappingPreset.php
+++ b/src/MappingPreset/MetaMappingPreset.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\MappingPreset;
+
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
+use Setono\SyliusFeedPlugin\Transformation\StripTags;
+use Setono\SyliusFeedPlugin\Transformation\Truncate;
+use Setono\SyliusFeedPlugin\Transformation\ValueMap;
+
+/**
+ * Seeds a Meta (Facebook/Instagram) catalog feed (§7): the `csv` format plus the default
+ * output→source field mappings for the `product_variant` feed type. Meta's CSV columns are
+ * unprefixed (unlike Google's `g:`-prefixed XML fields) and its availability vocabulary uses
+ * spaces rather than underscores.
+ */
+final class MetaMappingPreset implements MappingPresetInterface
+{
+    public function getCode(): string
+    {
+        return 'meta';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.mapping_preset.meta';
+    }
+
+    public function supports(string $feedType): bool
+    {
+        return 'product_variant' === $feedType;
+    }
+
+    public function getFormat(): string
+    {
+        return 'csv';
+    }
+
+    public function getMapping(): array
+    {
+        return [
+            FieldMapping::field('id', 'id'),
+            FieldMapping::field('title', 'title')->transform(Truncate::chars(150)),
+            FieldMapping::field('description', 'description')
+                ->transform(StripTags::all())
+                ->transform(Truncate::chars(5000)),
+            FieldMapping::field('availability', 'availability')->transform(ValueMap::of([
+                'in_stock' => 'in stock',
+                'out_of_stock' => 'out of stock',
+                'preorder' => 'available for order',
+                'backorder' => 'available for order',
+            ])),
+            FieldMapping::literal('condition', 'new'),
+            FieldMapping::field('price', 'channel_price')->transform(MoneyFormat::withCurrency()),
+            FieldMapping::field('link', 'link'),
+            FieldMapping::field('image_link', 'main_image'),
+            FieldMapping::field('additional_image_link', 'additional_images'),
+            FieldMapping::field('item_group_id', 'item_group_id')->onlyIf('is_configurable'),
+            // Required by Meta but not derivable from core Sylius → flagged for the admin to
+            // complete before the feed can be enabled:
+            FieldMapping::field('brand', 'attribute:brand')->requiresInput(),
+        ];
+    }
+}

--- a/src/MappingPreset/PartnerAdsMappingPreset.php
+++ b/src/MappingPreset/PartnerAdsMappingPreset.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\MappingPreset;
+
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
+use Setono\SyliusFeedPlugin\Transformation\StripTags;
+
+/**
+ * Seeds a Partner-ads product feed (§7): the `partner_ads` format plus the default output→source
+ * field mappings for the `product_variant` feed type. Partner-ads is a Danish affiliate network,
+ * hence the Danish element names (`produktnavn`, `VareURL`, `køn`, …).
+ */
+final class PartnerAdsMappingPreset implements MappingPresetInterface
+{
+    public function getCode(): string
+    {
+        return 'partner_ads';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.mapping_preset.partner_ads';
+    }
+
+    public function supports(string $feedType): bool
+    {
+        return 'product_variant' === $feedType;
+    }
+
+    public function getFormat(): string
+    {
+        return 'partner_ads';
+    }
+
+    public function getMapping(): array
+    {
+        return [
+            FieldMapping::field('produktid', 'id'),
+            FieldMapping::field('produktnavn', 'title'),
+            FieldMapping::field('beskrivelse', 'description')->transform(StripTags::all()),
+            FieldMapping::field('nypris', 'channel_price')->transform(MoneyFormat::withCurrency()),
+            FieldMapping::field('glpris', 'original_price')
+                ->transform(MoneyFormat::withCurrency())
+                ->onlyIf('on_sale'),
+            FieldMapping::field('VareURL', 'link'),
+            FieldMapping::field('BilledURL', 'main_image'),
+            // Required by Partner-ads but not derivable from core Sylius → flagged for the admin
+            // to complete before the feed can be enabled:
+            FieldMapping::field('brand', 'attribute:brand')->requiresInput(),
+            FieldMapping::field('køn', 'attribute:gender')->requiresInput(),
+        ];
+    }
+}

--- a/src/MappingPreset/PinterestMappingPreset.php
+++ b/src/MappingPreset/PinterestMappingPreset.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\MappingPreset;
+
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
+use Setono\SyliusFeedPlugin\Transformation\StripTags;
+use Setono\SyliusFeedPlugin\Transformation\Truncate;
+
+/**
+ * Seeds a Pinterest product feed (§7): the `google_rss` format plus the default output→source
+ * field mappings for the `product_variant` feed type. Pinterest consumes the same `g`-namespaced
+ * RSS vocabulary as Google Shopping, so the mapping is identical.
+ */
+final class PinterestMappingPreset implements MappingPresetInterface
+{
+    public function getCode(): string
+    {
+        return 'pinterest';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.mapping_preset.pinterest';
+    }
+
+    public function supports(string $feedType): bool
+    {
+        return 'product_variant' === $feedType;
+    }
+
+    public function getFormat(): string
+    {
+        return 'google_rss';
+    }
+
+    public function getMapping(): array
+    {
+        return [
+            FieldMapping::field('g:id', 'id'),
+            FieldMapping::field('g:item_group_id', 'item_group_id')->onlyIf('is_configurable'),
+            FieldMapping::field('g:title', 'title')->transform(Truncate::chars(150)),
+            FieldMapping::field('g:description', 'description')
+                ->transform(StripTags::all())
+                ->transform(Truncate::chars(5000)),
+            FieldMapping::field('g:link', 'link'),
+            FieldMapping::field('g:image_link', 'main_image'),
+            FieldMapping::field('g:additional_image_link', 'additional_images'),
+            FieldMapping::field('g:availability', 'availability'),
+            FieldMapping::field('g:price', 'channel_price')->transform(MoneyFormat::withCurrency()),
+            FieldMapping::literal('g:condition', 'new'),
+            // Required/expected by Pinterest but not derivable from core Sylius → flagged for the
+            // admin to complete before the feed can be enabled:
+            FieldMapping::field('g:brand', 'attribute:brand')->requiresInput(),
+            FieldMapping::field('g:gtin', 'attribute:gtin')->requiresInput(),
+            FieldMapping::field('g:google_product_category', 'attribute:google_product_category')->requiresInput(),
+        ];
+    }
+}

--- a/src/MappingPreset/TikTokMappingPreset.php
+++ b/src/MappingPreset/TikTokMappingPreset.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\MappingPreset;
+
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
+use Setono\SyliusFeedPlugin\Transformation\StripTags;
+use Setono\SyliusFeedPlugin\Transformation\Truncate;
+
+/**
+ * Seeds a TikTok Shop product feed (§7): the `csv` format plus the default output→source field
+ * mappings for the `product_variant` feed type. TikTok uses its own column names (`sku_id`,
+ * `product_page_url`) rather than Google's vocabulary.
+ */
+final class TikTokMappingPreset implements MappingPresetInterface
+{
+    public function getCode(): string
+    {
+        return 'tiktok';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.mapping_preset.tiktok';
+    }
+
+    public function supports(string $feedType): bool
+    {
+        return 'product_variant' === $feedType;
+    }
+
+    public function getFormat(): string
+    {
+        return 'csv';
+    }
+
+    public function getMapping(): array
+    {
+        return [
+            FieldMapping::field('sku_id', 'id'),
+            FieldMapping::field('title', 'title')->transform(Truncate::chars(150)),
+            FieldMapping::field('description', 'description')->transform(StripTags::all()),
+            FieldMapping::field('availability', 'availability'),
+            FieldMapping::field('price', 'channel_price')->transform(MoneyFormat::withCurrency()),
+            FieldMapping::field('product_page_url', 'link'),
+            FieldMapping::field('image_link', 'main_image'),
+            // Required by TikTok but not derivable from core Sylius → flagged for the admin to
+            // complete before the feed can be enabled:
+            FieldMapping::field('brand', 'attribute:brand')->requiresInput(),
+        ];
+    }
+}

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -28,5 +28,11 @@ final class AdminMenuListener
             ->setLabel('setono_sylius_feed.ui.feeds')
             ->setLabelAttribute('icon', 'rss')
         ;
+
+        $catalog
+            ->addChild('setono_sylius_feed_lookup_tables', ['route' => 'setono_sylius_feed_admin_lookup_table_index'])
+            ->setLabel('setono_sylius_feed.ui.lookup_tables')
+            ->setLabelAttribute('icon', 'database')
+        ;
     }
 }

--- a/src/Model/LookupTable.php
+++ b/src/Model/LookupTable.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+class LookupTable implements LookupTableInterface
+{
+    protected ?int $id = null;
+
+    protected ?string $code = null;
+
+    protected ?string $name = null;
+
+    protected ?string $sourceType = null;
+
+    /** @var array<string, mixed> */
+    protected array $sourceConfig = [];
+
+    protected ?string $keyColumn = null;
+
+    protected ?string $joinField = null;
+
+    protected string $refreshPolicy = self::REFRESH_POLICY_MANUAL;
+
+    protected ?\DateTimeInterface $refreshedAt = null;
+
+    /** @var array<string, array<string, scalar|null>> */
+    protected array $rows = [];
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getSourceType(): ?string
+    {
+        return $this->sourceType;
+    }
+
+    public function setSourceType(?string $sourceType): void
+    {
+        $this->sourceType = $sourceType;
+    }
+
+    public function getSourceConfig(): array
+    {
+        return $this->sourceConfig;
+    }
+
+    public function setSourceConfig(array $sourceConfig): void
+    {
+        $this->sourceConfig = $sourceConfig;
+    }
+
+    public function getKeyColumn(): ?string
+    {
+        return $this->keyColumn;
+    }
+
+    public function setKeyColumn(?string $keyColumn): void
+    {
+        $this->keyColumn = $keyColumn;
+    }
+
+    public function getJoinField(): ?string
+    {
+        return $this->joinField;
+    }
+
+    public function setJoinField(?string $joinField): void
+    {
+        $this->joinField = $joinField;
+    }
+
+    public function getRefreshPolicy(): string
+    {
+        return $this->refreshPolicy;
+    }
+
+    public function setRefreshPolicy(string $refreshPolicy): void
+    {
+        $this->refreshPolicy = $refreshPolicy;
+    }
+
+    public function getRefreshedAt(): ?\DateTimeInterface
+    {
+        return $this->refreshedAt;
+    }
+
+    public function setRefreshedAt(?\DateTimeInterface $refreshedAt): void
+    {
+        $this->refreshedAt = $refreshedAt;
+    }
+
+    public function getRows(): array
+    {
+        return $this->rows;
+    }
+
+    public function setRows(array $rows): void
+    {
+        $this->rows = $rows;
+    }
+
+    public function getRow(string $key): ?array
+    {
+        return $this->rows[$key] ?? null;
+    }
+
+    public function getColumn(string $key, string $column): mixed
+    {
+        return $this->rows[$key][$column] ?? null;
+    }
+}

--- a/src/Model/LookupTableInterface.php
+++ b/src/Model/LookupTableInterface.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+use Sylius\Component\Resource\Model\CodeAwareInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+/**
+ * A standalone, admin-managed enrichment dataset (§10.1): a key => row store that resolvers join
+ * against per item. Rows are imported from a source (csv/url) and refreshed with a keep-last-good
+ * policy, so a failed refresh never blanks the currently-serving data.
+ */
+interface LookupTableInterface extends ResourceInterface, CodeAwareInterface
+{
+    public const SOURCE_TYPE_CSV = 'csv';
+
+    public const SOURCE_TYPE_URL = 'url';
+
+    public const REFRESH_POLICY_MANUAL = 'manual';
+
+    public const REFRESH_POLICY_BEFORE_GENERATE = 'before_generate';
+
+    public const REFRESH_POLICY_SCHEDULED = 'scheduled';
+
+    public function getId(): ?int;
+
+    public function getName(): ?string;
+
+    public function setName(?string $name): void;
+
+    /**
+     * The lookup source type importing the rows, e.g. `csv` or `url`.
+     */
+    public function getSourceType(): ?string;
+
+    public function setSourceType(?string $sourceType): void;
+
+    /**
+     * Source-specific configuration, e.g. `['path' => '...']` (csv) or `['url' => '...']` (url).
+     *
+     * @return array<string, mixed>
+     */
+    public function getSourceConfig(): array;
+
+    /**
+     * @param array<string, mixed> $sourceConfig
+     */
+    public function setSourceConfig(array $sourceConfig): void;
+
+    /**
+     * The source column whose value is the row's join key.
+     */
+    public function getKeyColumn(): ?string;
+
+    public function setKeyColumn(?string $keyColumn): void;
+
+    /**
+     * The item source-field whose value supplies the join key when resolving `lookup:{code}:{column}`.
+     */
+    public function getJoinField(): ?string;
+
+    public function setJoinField(?string $joinField): void;
+
+    public function getRefreshPolicy(): string;
+
+    public function setRefreshPolicy(string $refreshPolicy): void;
+
+    public function getRefreshedAt(): ?\DateTimeInterface;
+
+    public function setRefreshedAt(?\DateTimeInterface $refreshedAt): void;
+
+    /**
+     * The imported keyed store: join key => (column => value).
+     *
+     * @return array<string, array<string, scalar|null>>
+     */
+    public function getRows(): array;
+
+    /**
+     * @param array<string, array<string, scalar|null>> $rows
+     */
+    public function setRows(array $rows): void;
+
+    /**
+     * The stored row for the given join key, or null on a miss.
+     *
+     * @return array<string, scalar|null>|null
+     */
+    public function getRow(string $key): ?array;
+
+    /**
+     * The stored value at the given join key and column, or null on a miss.
+     *
+     * @return scalar|null
+     */
+    public function getColumn(string $key, string $column): mixed;
+}

--- a/src/Repository/LookupTableRepository.php
+++ b/src/Repository/LookupTableRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Repository;
+
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+
+class LookupTableRepository extends EntityRepository implements LookupTableRepositoryInterface
+{
+    public function findOneByCode(string $code): ?LookupTableInterface
+    {
+        $result = $this->findOneBy(['code' => $code]);
+
+        return $result instanceof LookupTableInterface ? $result : null;
+    }
+}

--- a/src/Repository/LookupTableRepositoryInterface.php
+++ b/src/Repository/LookupTableRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Repository;
+
+use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @extends RepositoryInterface<LookupTableInterface>
+ */
+interface LookupTableRepositoryInterface extends RepositoryInterface
+{
+    public function findOneByCode(string $code): ?LookupTableInterface;
+}

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -73,3 +73,40 @@ sylius_grid:
                         type: update
                     delete:
                         type: delete
+        setono_sylius_feed_lookup_table:
+            driver:
+                name: doctrine/orm
+                options:
+                    class: '%setono_sylius_feed.model.lookup_table.class%'
+            fields:
+                code:
+                    type: string
+                    label: sylius.ui.code
+                    sortable: ~
+                sourceType:
+                    type: string
+                    label: setono_sylius_feed.form.lookup_table.source_type
+                refreshedAt:
+                    type: datetime
+                    label: setono_sylius_feed.ui.refreshed_at
+                    sortable: ~
+                    options:
+                        format: 'Y-m-d H:i'
+            actions:
+                main:
+                    create:
+                        type: create
+                item:
+                    refresh:
+                        type: default
+                        label: setono_sylius_feed.ui.refresh
+                        icon: sync
+                        options:
+                            link:
+                                route: setono_sylius_feed_admin_lookup_table_refresh
+                                parameters:
+                                    id: resource.id
+                    update:
+                        type: update
+                    delete:
+                        type: delete

--- a/src/Resources/config/doctrine/model/LookupTable.orm.xml
+++ b/src/Resources/config/doctrine/model/LookupTable.orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<doctrine-mapping xmlns="http://doctrine.apache.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine.apache.org/schemas/orm/doctrine-mapping
+                  http://doctrine.apache.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Setono\SyliusFeedPlugin\Model\LookupTable" table="setono_sylius_feed__lookup_table">
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="code" type="string" unique="true"/>
+        <field name="name" type="string" nullable="true"/>
+        <field name="sourceType" column="source_type" type="string" nullable="true"/>
+        <field name="sourceConfig" column="source_config" type="json"/>
+        <field name="keyColumn" column="key_column" type="string" nullable="true"/>
+        <field name="joinField" column="join_field" type="string" nullable="true"/>
+        <field name="refreshPolicy" column="refresh_policy" type="string"/>
+        <field name="refreshedAt" column="refreshed_at" type="datetime_immutable" nullable="true"/>
+        <field name="rows" column="lookup_rows" type="json"/>
+    </entity>
+</doctrine-mapping>

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -23,3 +23,23 @@ setono_sylius_feed_admin_feed_results:
     methods: [GET]
     defaults:
         _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\FeedResultsAction'
+
+setono_sylius_feed_admin_lookup_table:
+    resource: |
+        alias: setono_sylius_feed.lookup_table
+        section: admin
+        templates: "@SyliusAdmin/Crud"
+        redirect: update
+        grid: setono_sylius_feed_lookup_table
+        vars:
+            all:
+                subheader: setono_sylius_feed.ui.manage_lookup_tables
+            index:
+                icon: database
+    type: sylius.resource
+
+setono_sylius_feed_admin_lookup_table_refresh:
+    path: /lookup-tables/{id}/refresh
+    methods: [GET]
+    defaults:
+        _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\RefreshLookupTableAction'

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -17,6 +17,13 @@
             <tag name="controller.service_arguments"/>
         </service>
 
+        <service id="Setono\SyliusFeedPlugin\Controller\Admin\RefreshLookupTableAction">
+            <argument type="service" id="setono_sylius_feed.repository.lookup_table"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresherInterface"/>
+            <argument type="service" id="router"/>
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="Setono\SyliusFeedPlugin\Controller\Admin\FeedResultsAction">
             <argument type="service" id="setono_sylius_feed.repository.feed"/>
             <argument type="service" id="setono_sylius_feed.storage.feed"/>

--- a/src/Resources/config/services/feed_type.xml
+++ b/src/Resources/config/services/feed_type.xml
@@ -14,5 +14,16 @@
             <argument type="service" id="Setono\SyliusFeedPlugin\ValueResolver\ValueResolverRegistryInterface"/>
             <tag name="setono_sylius_feed.feed_type"/>
         </service>
+
+        <service id="Setono\SyliusFeedPlugin\DataSource\ProductDataSource">
+            <argument type="service" id="doctrine"/>
+            <argument>%sylius.model.product.class%</argument>
+        </service>
+
+        <service id="Setono\SyliusFeedPlugin\FeedType\ProductFeedType">
+            <argument type="service" id="Setono\SyliusFeedPlugin\DataSource\ProductDataSource"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\ValueResolver\ValueResolverRegistryInterface"/>
+            <tag name="setono_sylius_feed.feed_type"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -28,5 +28,10 @@
         <service id="Setono\SyliusFeedPlugin\Form\Type\FeedFieldType">
             <tag name="form.type"/>
         </service>
+
+        <service id="Setono\SyliusFeedPlugin\Form\Type\LookupTableType">
+            <argument>%setono_sylius_feed.model.lookup_table.class%</argument>
+            <tag name="form.type"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/format.xml
+++ b/src/Resources/config/services/format.xml
@@ -10,5 +10,11 @@
         <service id="Setono\SyliusFeedPlugin\Format\CsvFormat">
             <tag name="setono_sylius_feed.format"/>
         </service>
+        <service id="Setono\SyliusFeedPlugin\Format\GenericXmlFormat">
+            <tag name="setono_sylius_feed.format"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Format\PartnerAdsFormat">
+            <tag name="setono_sylius_feed.format"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/format.xml
+++ b/src/Resources/config/services/format.xml
@@ -7,5 +7,8 @@
         <service id="Setono\SyliusFeedPlugin\Format\GoogleRssFormat">
             <tag name="setono_sylius_feed.format"/>
         </service>
+        <service id="Setono\SyliusFeedPlugin\Format\CsvFormat">
+            <tag name="setono_sylius_feed.format"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/generator.xml
+++ b/src/Resources/config/services/generator.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Scripting\ExpressionEvaluatorInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Scripting\TwigTemplateRendererInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface"/>
         </service>
         <service id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface" alias="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator"/>
 

--- a/src/Resources/config/services/lookup.xml
+++ b/src/Resources/config/services/lookup.xml
@@ -10,5 +10,20 @@
             <argument type="service" id="setono_sylius_feed.repository.lookup_table"/>
         </service>
         <service id="Setono\SyliusFeedPlugin\Lookup\LookupInterface" alias="Setono\SyliusFeedPlugin\Lookup\DatabaseLookup"/>
+
+        <service id="Setono\SyliusFeedPlugin\Lookup\CsvLookupSource">
+            <argument type="service" id="setono_sylius_feed.storage.feed"/>
+            <tag name="setono_sylius_feed.lookup_source"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Lookup\UrlLookupSource">
+            <tag name="setono_sylius_feed.lookup_source"/>
+        </service>
+
+        <service id="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresher">
+            <argument type="service" id="doctrine"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupSourceRegistryInterface"/>
+            <argument type="service" id="logger"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresherInterface" alias="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresher"/>
     </services>
 </container>

--- a/src/Resources/config/services/lookup.xml
+++ b/src/Resources/config/services/lookup.xml
@@ -5,6 +5,10 @@
 
     <services>
         <service id="Setono\SyliusFeedPlugin\Lookup\InMemoryLookup"/>
-        <service id="Setono\SyliusFeedPlugin\Lookup\LookupInterface" alias="Setono\SyliusFeedPlugin\Lookup\InMemoryLookup"/>
+
+        <service id="Setono\SyliusFeedPlugin\Lookup\DatabaseLookup">
+            <argument type="service" id="setono_sylius_feed.repository.lookup_table"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Lookup\LookupInterface" alias="Setono\SyliusFeedPlugin\Lookup\DatabaseLookup"/>
     </services>
 </container>

--- a/src/Resources/config/services/lookup.xml
+++ b/src/Resources/config/services/lookup.xml
@@ -25,5 +25,10 @@
             <argument type="service" id="logger"/>
         </service>
         <service id="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresherInterface" alias="Setono\SyliusFeedPlugin\Lookup\LookupTableRefresher"/>
+
+        <service id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolver">
+            <argument type="service" id="setono_sylius_feed.repository.lookup_table"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface" alias="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolver"/>
     </services>
 </container>

--- a/src/Resources/config/services/mapping_preset.xml
+++ b/src/Resources/config/services/mapping_preset.xml
@@ -12,5 +12,20 @@
         <service id="Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset">
             <tag name="setono_sylius_feed.mapping_preset"/>
         </service>
+        <service id="Setono\SyliusFeedPlugin\MappingPreset\MetaMappingPreset">
+            <tag name="setono_sylius_feed.mapping_preset"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\MappingPreset\BingMappingPreset">
+            <tag name="setono_sylius_feed.mapping_preset"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\MappingPreset\PinterestMappingPreset">
+            <tag name="setono_sylius_feed.mapping_preset"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\MappingPreset\TikTokMappingPreset">
+            <tag name="setono_sylius_feed.mapping_preset"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\MappingPreset\PartnerAdsMappingPreset">
+            <tag name="setono_sylius_feed.mapping_preset"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/value_resolver.xml
+++ b/src/Resources/config/services/value_resolver.xml
@@ -45,5 +45,15 @@
         <service id="Setono\SyliusFeedPlugin\ValueResolver\Product\OnSaleResolver">
             <tag name="setono_sylius_feed.value_resolver"/>
         </service>
+        <service id="Setono\SyliusFeedPlugin\ValueResolver\Product\VariantCountResolver">
+            <tag name="setono_sylius_feed.value_resolver"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\ValueResolver\Product\FromPriceResolver">
+            <argument type="service" id="Setono\SyliusFeedPlugin\Currency\ContextCurrencyConverterInterface"/>
+            <tag name="setono_sylius_feed.value_resolver"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\ValueResolver\Product\ProductAvailabilityResolver">
+            <tag name="setono_sylius_feed.value_resolver"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/writer.xml
+++ b/src/Resources/config/services/writer.xml
@@ -7,5 +7,8 @@
         <service id="Setono\SyliusFeedPlugin\Writer\XmlWriter">
             <tag name="setono_sylius_feed.writer"/>
         </service>
+        <service id="Setono\SyliusFeedPlugin\Writer\CsvWriter">
+            <tag name="setono_sylius_feed.writer"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/translations/flashes.en.yaml
+++ b/src/Resources/translations/flashes.en.yaml
@@ -1,3 +1,5 @@
 setono_sylius_feed:
     feed:
         generation_dispatched: Feed generation has been dispatched
+    lookup_table:
+        refreshed: Lookup table has been refreshed

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -1,7 +1,13 @@
 setono_sylius_feed:
     ui:
         feeds: Feeds
+        lookup_tables: Lookup tables
+        new_lookup_table: New lookup table
+        edit_lookup_table: Edit lookup table
         manage_feeds: Manage feeds
+        manage_lookup_tables: Manage lookup tables
+        refresh: Refresh
+        refreshed_at: Refreshed at
         new_feed: New feed
         edit_feed: Edit feed
         state: State
@@ -36,6 +42,23 @@ setono_sylius_feed:
                 literal: Literal
                 expression: Expression
                 twig: Twig
+        lookup_table:
+            name: Name
+            source_type: Source type
+            location: Source location
+            location_help: 'The uploaded CSV path (csv source) or the CSV/TSV URL — e.g. a published Google Sheet …/export?format=csv (url source).'
+            key_column: Key column
+            join_field: Join field
+            refresh_policy: Refresh policy
+            source:
+                csv: CSV file
+                url: URL
+            policy:
+                manual: Manual
+                before_generate: Before generate
+                scheduled: Scheduled
+    lookup_table:
+        refreshed: Lookup table has been refreshed
     mapping_preset:
         google_shopping: Google Shopping
         meta: Meta

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -43,3 +43,10 @@ setono_sylius_feed:
         pinterest: Pinterest
         tiktok: TikTok
         partner_ads: Partner-ads
+    feed_type:
+        product_variant: Product variant
+        product: Product
+    value_resolver:
+        variant_count: Number of variants
+        from_price: From price
+        product_availability: Availability

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -38,3 +38,8 @@ setono_sylius_feed:
                 twig: Twig
     mapping_preset:
         google_shopping: Google Shopping
+        meta: Meta
+        bing: Bing
+        pinterest: Pinterest
+        tiktok: TikTok
+        partner_ads: Partner-ads

--- a/src/ValueResolver/Product/AdditionalImagesResolver.php
+++ b/src/ValueResolver/Product/AdditionalImagesResolver.php
@@ -8,15 +8,15 @@ use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
-use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 
 /**
  * The product's additional images (all but the first) as absolute, filtered URLs, capped at 10
- * per Google's limit (§8.1).
+ * per Google's limit (§8.1, §8.7).
  */
 final class AdditionalImagesResolver implements ValueResolverInterface
 {
+    use ProductAwareTrait;
+
     private const LIMIT = 10;
 
     public function __construct(
@@ -40,19 +40,10 @@ final class AdditionalImagesResolver implements ValueResolverInterface
         return FieldType::IMAGE;
     }
 
-    public function supports(string $resourceClass): bool
-    {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
-    }
-
     public function resolve(object $entity, FeedContext $context): mixed
     {
-        if (!$entity instanceof ProductVariantInterface) {
-            return [];
-        }
-
-        $product = $entity->getProduct();
-        if (!$product instanceof ProductInterface) {
+        $product = $this->resolveProduct($entity);
+        if (null === $product) {
             return [];
         }
 

--- a/src/ValueResolver/Product/DescriptionResolver.php
+++ b/src/ValueResolver/Product/DescriptionResolver.php
@@ -7,13 +7,14 @@ namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 
 /**
- * The translated product description for the context locale (§8.1).
+ * The translated product description for the context locale (§8.1, §8.7).
  */
 final class DescriptionResolver implements ValueResolverInterface
 {
+    use ProductAwareTrait;
+
     public function getName(): string
     {
         return 'description';
@@ -29,19 +30,14 @@ final class DescriptionResolver implements ValueResolverInterface
         return FieldType::STRING;
     }
 
-    public function supports(string $resourceClass): bool
-    {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
-    }
-
     public function resolve(object $entity, FeedContext $context): mixed
     {
         $locale = $context->getLocale();
-        if (!$entity instanceof ProductVariantInterface || null === $locale) {
+        if (null === $locale) {
             return null;
         }
 
-        $product = $entity->getProduct();
+        $product = $this->resolveProduct($entity);
         if (null === $product) {
             return null;
         }

--- a/src/ValueResolver/Product/FromPriceResolver.php
+++ b/src/ValueResolver/Product/FromPriceResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Currency\ContextCurrencyConverterInterface;
+use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * The cheapest enabled variant's price for the context channel, in minor units, FX-converted to the
+ * context currency (§8.7, §9.1). The "from" price shown on a product-level row of a configurable
+ * product.
+ */
+final class FromPriceResolver implements ValueResolverInterface
+{
+    public function __construct(private readonly ContextCurrencyConverterInterface $currencyConverter)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'from_price';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.value_resolver.from_price';
+    }
+
+    public function getType(): FieldType
+    {
+        return FieldType::MONEY;
+    }
+
+    public function supports(string $resourceClass): bool
+    {
+        return is_a($resourceClass, ProductInterface::class, true);
+    }
+
+    public function resolve(object $entity, FeedContext $context): mixed
+    {
+        $channel = $context->getChannel();
+        if (!$entity instanceof ProductInterface || !$channel instanceof ChannelInterface) {
+            return null;
+        }
+
+        $lowest = null;
+        foreach ($entity->getVariants() as $variant) {
+            if (!$variant instanceof ProductVariantInterface || !$variant->isEnabled()) {
+                continue;
+            }
+
+            $price = $variant->getChannelPricingForChannel($channel)?->getPrice();
+            if (null !== $price && (null === $lowest || $price < $lowest)) {
+                $lowest = $price;
+            }
+        }
+
+        return null === $lowest ? null : $this->currencyConverter->convert($lowest, $channel, $context);
+    }
+}

--- a/src/ValueResolver/Product/IdResolver.php
+++ b/src/ValueResolver/Product/IdResolver.php
@@ -7,10 +7,12 @@ namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 /**
- * The variant's code — the per-item `id` for a product_variant feed (§8.1).
+ * The per-item `id` (§8.1, §8.7): a variant resolves to the variant's own code, a product resolves
+ * to the product's code.
  */
 final class IdResolver implements ValueResolverInterface
 {
@@ -31,11 +33,20 @@ final class IdResolver implements ValueResolverInterface
 
     public function supports(string $resourceClass): bool
     {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
+        return is_a($resourceClass, ProductVariantInterface::class, true) ||
+            is_a($resourceClass, ProductInterface::class, true);
     }
 
     public function resolve(object $entity, FeedContext $context): mixed
     {
-        return $entity instanceof ProductVariantInterface ? $entity->getCode() : null;
+        if ($entity instanceof ProductVariantInterface) {
+            return $entity->getCode();
+        }
+
+        if ($entity instanceof ProductInterface) {
+            return $entity->getCode();
+        }
+
+        return null;
     }
 }

--- a/src/ValueResolver/Product/IsConfigurableResolver.php
+++ b/src/ValueResolver/Product/IsConfigurableResolver.php
@@ -7,14 +7,15 @@ namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 
 /**
- * Whether the variant's product is configurable (has more than one variant) — drives the
- * `item_group_id` emit condition (§8.1).
+ * Whether the product is configurable (has more than one variant) — drives the `item_group_id`
+ * emit condition (§8.1, §8.7).
  */
 final class IsConfigurableResolver implements ValueResolverInterface
 {
+    use ProductAwareTrait;
+
     public function getName(): string
     {
         return 'is_configurable';
@@ -30,17 +31,13 @@ final class IsConfigurableResolver implements ValueResolverInterface
         return FieldType::BOOL;
     }
 
-    public function supports(string $resourceClass): bool
-    {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
-    }
-
     public function resolve(object $entity, FeedContext $context): mixed
     {
-        if (!$entity instanceof ProductVariantInterface) {
+        $product = $this->resolveProduct($entity);
+        if (null === $product) {
             return null;
         }
 
-        return $entity->getProduct()?->getVariants()->count() > 1;
+        return $product->getVariants()->count() > 1;
     }
 }

--- a/src/ValueResolver/Product/MainImageResolver.php
+++ b/src/ValueResolver/Product/MainImageResolver.php
@@ -9,14 +9,14 @@ use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 
 /**
- * The product's main image as an absolute, filtered (LiipImagine) URL (§8.1, §9.6).
+ * The product's main image as an absolute, filtered (LiipImagine) URL (§8.1, §8.7, §9.6).
  */
 final class MainImageResolver implements ValueResolverInterface
 {
+    use ProductAwareTrait;
+
     public function __construct(
         private readonly CacheManager $cacheManager,
         private readonly string $filterSet = 'sylius_shop_product_large_thumbnail',
@@ -38,19 +38,10 @@ final class MainImageResolver implements ValueResolverInterface
         return FieldType::IMAGE;
     }
 
-    public function supports(string $resourceClass): bool
-    {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
-    }
-
     public function resolve(object $entity, FeedContext $context): mixed
     {
-        if (!$entity instanceof ProductVariantInterface) {
-            return null;
-        }
-
-        $product = $entity->getProduct();
-        if (!$product instanceof ProductInterface) {
+        $product = $this->resolveProduct($entity);
+        if (null === $product) {
             return null;
         }
 

--- a/src/ValueResolver/Product/ProductAvailabilityResolver.php
+++ b/src/ValueResolver/Product/ProductAvailabilityResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Item\Google\Availability;
+use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * Maps a product's inventory to an availability value (§8.7, §9.7): the product is in stock when any
+ * of its variants is in stock — an untracked variant is always in stock, a tracked one is in stock
+ * when its available quantity (on-hand minus on-hold) is positive.
+ */
+final class ProductAvailabilityResolver implements ValueResolverInterface
+{
+    public function getName(): string
+    {
+        return 'product_availability';
+    }
+
+    public function getLabel(): string
+    {
+        return 'setono_sylius_feed.value_resolver.product_availability';
+    }
+
+    public function getType(): FieldType
+    {
+        return FieldType::STRING;
+    }
+
+    public function supports(string $resourceClass): bool
+    {
+        return is_a($resourceClass, ProductInterface::class, true);
+    }
+
+    public function resolve(object $entity, FeedContext $context): mixed
+    {
+        if (!$entity instanceof ProductInterface) {
+            return null;
+        }
+
+        foreach ($entity->getVariants() as $variant) {
+            if (!$variant instanceof ProductVariantInterface) {
+                continue;
+            }
+
+            if (!$variant->isTracked()) {
+                return Availability::IN_STOCK->value;
+            }
+
+            if ((int) $variant->getOnHand() - (int) $variant->getOnHold() > 0) {
+                return Availability::IN_STOCK->value;
+            }
+        }
+
+        return Availability::OUT_OF_STOCK->value;
+    }
+}

--- a/src/ValueResolver/Product/ProductAwareTrait.php
+++ b/src/ValueResolver/Product/ProductAwareTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
+
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * Shared behaviour for value resolvers that expose a product-level field and therefore work against
+ * both a product variant and a product (§8.1, §8.7): they support either entity and derive the
+ * backing {@see ProductInterface} the same way.
+ */
+trait ProductAwareTrait
+{
+    public function supports(string $resourceClass): bool
+    {
+        return is_a($resourceClass, ProductVariantInterface::class, true) ||
+            is_a($resourceClass, ProductInterface::class, true);
+    }
+
+    /**
+     * Derives the product from either a variant (via its parent) or a product entity, or null for
+     * anything else.
+     */
+    private function resolveProduct(object $entity): ?ProductInterface
+    {
+        if ($entity instanceof ProductVariantInterface) {
+            $product = $entity->getProduct();
+
+            return $product instanceof ProductInterface ? $product : null;
+        }
+
+        if ($entity instanceof ProductInterface) {
+            return $entity;
+        }
+
+        return null;
+    }
+}

--- a/src/ValueResolver/Product/ProductUrlResolver.php
+++ b/src/ValueResolver/Product/ProductUrlResolver.php
@@ -7,15 +7,16 @@ namespace Setono\SyliusFeedPlugin\ValueResolver\Product;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
- * The absolute product page URL for the context locale (§8.1, §9.3). The router context host is
- * set per channel by the generator so the URL is channel-correct.
+ * The absolute product page URL for the context locale (§8.1, §8.7, §9.3). The router context host
+ * is set per channel by the generator so the URL is channel-correct.
  */
 final class ProductUrlResolver implements ValueResolverInterface
 {
+    use ProductAwareTrait;
+
     public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
     {
     }
@@ -35,19 +36,14 @@ final class ProductUrlResolver implements ValueResolverInterface
         return FieldType::URL;
     }
 
-    public function supports(string $resourceClass): bool
-    {
-        return is_a($resourceClass, ProductVariantInterface::class, true);
-    }
-
     public function resolve(object $entity, FeedContext $context): mixed
     {
         $locale = $context->getLocale();
-        if (!$entity instanceof ProductVariantInterface || null === $locale) {
+        if (null === $locale) {
             return null;
         }
 
-        $product = $entity->getProduct();
+        $product = $this->resolveProduct($entity);
         if (null === $product) {
             return null;
         }

--- a/src/ValueResolver/Product/VariantCountResolver.php
+++ b/src/ValueResolver/Product/VariantCountResolver.php
@@ -9,39 +9,35 @@ use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
 
 /**
- * The translated product name for the context locale (§8.1, §8.7).
+ * The number of variants of the product (§8.7). Works against both a variant (via its parent) and a
+ * product entity.
  */
-final class TitleResolver implements ValueResolverInterface
+final class VariantCountResolver implements ValueResolverInterface
 {
     use ProductAwareTrait;
 
     public function getName(): string
     {
-        return 'title';
+        return 'variant_count';
     }
 
     public function getLabel(): string
     {
-        return 'setono_sylius_feed.value_resolver.title';
+        return 'setono_sylius_feed.value_resolver.variant_count';
     }
 
     public function getType(): FieldType
     {
-        return FieldType::STRING;
+        return FieldType::INTEGER;
     }
 
     public function resolve(object $entity, FeedContext $context): mixed
     {
-        $locale = $context->getLocale();
-        if (null === $locale) {
-            return null;
-        }
-
         $product = $this->resolveProduct($entity);
         if (null === $product) {
             return null;
         }
 
-        return $product->getTranslation($locale)->getName();
+        return $product->getVariants()->count();
     }
 }

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Writer;
+
+use League\Csv\ByteSequence;
+use League\Csv\Writer;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Webmozart\Assert\Assert;
+
+/**
+ * The "csv" writer family (§7): streams delimited text with `league/csv`. A single header row (the
+ * union of the feed's output fields) is written in the preamble, then one row per item where each
+ * cell is looked up by header column — a missing field becomes an empty cell, a list is joined,
+ * so heterogeneous multi-source rows line up under one header. league/csv handles quoting/escaping.
+ */
+final class CsvWriter implements FeedWriterInterface
+{
+    public const FORMAT = 'csv';
+
+    private ?Writer $writer = null;
+
+    /** @var list<string> */
+    private array $header = [];
+
+    public function getFormat(): string
+    {
+        return self::FORMAT;
+    }
+
+    public function open($stream, FeedContext $context, WriterConfigInterface $config): void
+    {
+        Assert::isInstanceOf($config, CsvWriterConfig::class);
+
+        // league/csv only prepends the output BOM via its own output methods, not when streaming
+        // records to an external stream — so write it directly before handing the stream over.
+        if ($config->bom) {
+            fwrite($stream, ByteSequence::BOM_UTF8);
+        }
+
+        $writer = Writer::createFromStream($stream);
+        $writer->setDelimiter($config->delimiter);
+        $writer->setEnclosure($config->enclosure);
+
+        $this->writer = $writer;
+        $this->header = $config->header;
+    }
+
+    public function writePreamble(): void
+    {
+        if ([] !== $this->header) {
+            $this->getWriter()->insertOne($this->header);
+        }
+    }
+
+    public function writeItem(FeedItem $item): void
+    {
+        $row = [];
+        foreach ($this->header as $column) {
+            $row[] = $this->toCell($item->get($column));
+        }
+
+        $this->getWriter()->insertOne($row);
+    }
+
+    public function writeEpilogue(): void
+    {
+        // CSV has no epilogue.
+    }
+
+    public function close(): void
+    {
+        // The generator owns the underlying stream; just drop the writer reference.
+        $this->writer = null;
+    }
+
+    private function toCell(mixed $value): string
+    {
+        if (is_array($value)) {
+            return implode(',', array_map($this->scalarToString(...), $value));
+        }
+
+        return $this->scalarToString($value);
+    }
+
+    private function scalarToString(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return is_scalar($value) ? (string) $value : '';
+    }
+
+    private function getWriter(): Writer
+    {
+        Assert::notNull($this->writer, 'The CSV writer has not been opened');
+
+        return $this->writer;
+    }
+}

--- a/src/Writer/CsvWriterConfig.php
+++ b/src/Writer/CsvWriterConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Writer;
+
+/**
+ * Structural configuration for the {@see CsvWriter} (§7): the delimiter/enclosure, whether to emit
+ * a UTF-8 BOM, and the header — the union of output fields across the feed's sources. The header is
+ * computed by the generator (it depends on the feed's mappings, not the static format preset) and
+ * injected via {@see withHeader()}.
+ */
+final class CsvWriterConfig implements WriterConfigInterface
+{
+    /**
+     * @param list<string> $header
+     */
+    public function __construct(
+        public readonly string $delimiter = ',',
+        public readonly string $enclosure = '"',
+        public readonly array $header = [],
+        public readonly bool $bom = false,
+    ) {
+    }
+
+    /**
+     * CSV has no preamble, so feed metadata is ignored.
+     */
+    public function withFeedMetadata(array $metadata): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param list<string> $header
+     */
+    public function withHeader(array $header): self
+    {
+        return new self($this->delimiter, $this->enclosure, $header, $this->bom);
+    }
+}

--- a/tests/Functional/DataSource/ProductDataSourceTest.php
+++ b/tests/Functional/DataSource/ProductDataSourceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Functional\DataSource;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\DataSource\ProductDataSource;
+use Setono\SyliusFeedPlugin\Filter\FilterSet;
+use Setono\SyliusFeedPlugin\Tests\Functional\FunctionalTestCase;
+use Sylius\Component\Core\Model\Channel;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariant;
+use Sylius\Component\Currency\Model\Currency;
+use Sylius\Component\Locale\Model\Locale;
+
+final class ProductDataSourceTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_the_product_class_and_counts_enabled_channel_assigned_products(): void
+    {
+        $channel = $this->persistFixtures();
+
+        $dataSource = self::getContainer()->get(ProductDataSource::class);
+        self::assertInstanceOf(ProductDataSource::class, $dataSource);
+
+        self::assertTrue(is_a($dataSource->getResourceClass(), ProductInterface::class, true));
+        self::assertSame(1, $dataSource->count(new FeedContext($channel, 'en_US', 'USD'), new FilterSet([])));
+    }
+
+    private function persistFixtures(): Channel
+    {
+        $currency = new Currency();
+        $currency->setCode('USD');
+
+        $locale = new Locale();
+        $locale->setCode('en_US');
+
+        $channel = new Channel();
+        $channel->setCode('web');
+        $channel->setName('Web');
+        $channel->setHostname('localhost');
+        $channel->setBaseCurrency($currency);
+        $channel->setDefaultLocale($locale);
+        $channel->addCurrency($currency);
+        $channel->addLocale($locale);
+        $channel->setTaxCalculationStrategy('order_items_based');
+        $channel->setEnabled(true);
+
+        // A disabled product that must not be counted.
+        $disabledProduct = new Product();
+        $disabledProduct->setCode('PROD-DISABLED');
+        $disabledProduct->setEnabled(false);
+        $disabledProduct->setCurrentLocale('en_US');
+        $disabledProduct->setFallbackLocale('en_US');
+        $disabledProduct->setName('Hidden');
+        $disabledProduct->setSlug('hidden');
+        $disabledProduct->addChannel($channel);
+
+        $product = new Product();
+        $product->setCode('PROD-1');
+        $product->setEnabled(true);
+        $product->setCurrentLocale('en_US');
+        $product->setFallbackLocale('en_US');
+        $product->setName('Acme Shoe');
+        $product->setSlug('acme-shoe');
+        $product->addChannel($channel);
+
+        $variant = new ProductVariant();
+        $variant->setCode('VARIANT-1');
+        $product->addVariant($variant);
+
+        $manager = self::getContainer()->get('doctrine.orm.entity_manager');
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+        foreach ([$currency, $locale, $channel, $disabledProduct, $product, $variant] as $entity) {
+            $manager->persist($entity);
+        }
+        $manager->flush();
+
+        return $channel;
+    }
+}

--- a/tests/Functional/FeedTypeWiringTest.php
+++ b/tests/Functional/FeedTypeWiringTest.php
@@ -9,6 +9,8 @@ use Setono\SyliusFeedPlugin\FeedType\ProductVariantFeedType;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistry;
+use Setono\SyliusFeedPlugin\MappingPreset\MetaMappingPreset;
+use Setono\SyliusFeedPlugin\MappingPreset\PartnerAdsMappingPreset;
 
 /**
  * Proves the M1 generation services are wired: the product_variant feed type and Google Shopping
@@ -36,7 +38,12 @@ final class FeedTypeWiringTest extends FunctionalTestCase
 
         self::assertInstanceOf(MappingPresetRegistry::class, $registry);
         self::assertInstanceOf(GoogleShoppingMappingPreset::class, $registry->get('google_shopping'));
-        self::assertSame([GoogleShoppingMappingPreset::class], array_map(get_class(...), $registry->forFeedType('product_variant')));
+
+        // every product-target preset supports the product_variant feed type
+        $presetClasses = array_map(get_class(...), $registry->forFeedType('product_variant'));
+        self::assertContains(GoogleShoppingMappingPreset::class, $presetClasses);
+        self::assertContains(MetaMappingPreset::class, $presetClasses);
+        self::assertContains(PartnerAdsMappingPreset::class, $presetClasses);
     }
 
     /**

--- a/tests/Functional/ProductFeedGenerationTest.php
+++ b/tests/Functional/ProductFeedGenerationTest.php
@@ -193,7 +193,7 @@ final class ProductFeedGenerationTest extends FunctionalTestCase
      */
     private function csvRecords(Reader $reader): array
     {
-        return array_values(array_filter(iterator_to_array($reader->getRecords()), is_array(...)));
+        return array_values(array_filter([...$reader->getRecords()], is_array(...)));
     }
 
     private function entityManager(): EntityManagerInterface

--- a/tests/Functional/ProductFeedGenerationTest.php
+++ b/tests/Functional/ProductFeedGenerationTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use League\Csv\Reader;
+use League\Flysystem\FilesystemOperator;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
+use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedField;
+use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSource;
+use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+use Sylius\Component\Core\Model\Channel;
+use Sylius\Component\Core\Model\ChannelPricing;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Core\Model\ProductVariant;
+use Sylius\Component\Currency\Model\Currency;
+use Sylius\Component\Locale\Model\Locale;
+
+/**
+ * End-to-end acceptance test for the `product` feed type (§8.7): persists a channel/product/variant
+ * and a CSV feed whose sources map product-level fields, runs the real generator (including the
+ * Doctrine data source) against the database, and asserts the stored CSV carries product-level rows.
+ * Also covers multi-source generation: one feed with both a `product` and a `product_variant` source
+ * emits both product-level and variant-level rows.
+ *
+ * Each test runs inside a transaction that is rolled back (dama/doctrine-test-bundle), so the
+ * database stays clean; generated files are removed in tearDown.
+ */
+final class ProductFeedGenerationTest extends FunctionalTestCase
+{
+    /** @var list<string> */
+    private array $generatedPaths = [];
+
+    protected function tearDown(): void
+    {
+        $filesystem = self::getContainer()->get('setono_sylius_feed.storage.feed_tmp');
+        if ($filesystem instanceof FilesystemOperator) {
+            foreach ($this->generatedPaths as $path) {
+                if ($filesystem->fileExists($path)) {
+                    $filesystem->delete($path);
+                }
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_product_level_csv_feed_from_the_database(): void
+    {
+        $channel = $this->persistFixtures();
+
+        $feed = new Feed();
+        $feed->setCode('products');
+        $feed->setFormat('csv');
+        $feed->setEnabled(true);
+        $feed->setCurrentLocale('en_US');
+        $feed->setName('Product feed');
+        $feed->setSlug('product-feed');
+        $feed->addChannel($channel);
+        $feed->addSource($this->source('product', 0, ['id', 'title', 'from_price']));
+
+        $this->persist($feed);
+
+        $result = $this->generate($feed, new FeedContext($channel, 'en_US', 'USD'));
+
+        self::assertSame('products/web_en_us_usd.csv', $result->path);
+        self::assertSame(1, $result->itemCount);
+
+        $reader = $this->read($result->path);
+
+        self::assertSame(['id', 'title', 'from_price'], $reader->getHeader());
+
+        $records = array_values(iterator_to_array($reader->getRecords()));
+        self::assertCount(1, $records);
+        self::assertSame('PROD-1', $records[0]['id']);
+        self::assertSame('Acme Shoe', $records[0]['title']);
+        self::assertSame('999', $records[0]['from_price']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_multi_source_feed_with_product_and_variant_rows(): void
+    {
+        $channel = $this->persistFixtures();
+
+        $feed = new Feed();
+        $feed->setCode('catalog');
+        $feed->setFormat('csv');
+        $feed->setEnabled(true);
+        $feed->setCurrentLocale('en_US');
+        $feed->setName('Catalog feed');
+        $feed->setSlug('catalog-feed');
+        $feed->addChannel($channel);
+        $feed->addSource($this->source('product', 0, ['id', 'title', 'from_price']));
+        $feed->addSource($this->source('product_variant', 1, ['id', 'title', 'channel_price']));
+
+        $this->persist($feed);
+
+        $result = $this->generate($feed, new FeedContext($channel, 'en_US', 'USD'));
+
+        self::assertSame('catalog/web_en_us_usd.csv', $result->path);
+        self::assertSame(2, $result->itemCount, 'one product row + one variant row');
+
+        $reader = $this->read($result->path);
+
+        $header = $reader->getHeader();
+        self::assertSame(['id', 'title', 'from_price', 'channel_price'], $header);
+
+        $byId = [];
+        foreach ($reader->getRecords() as $record) {
+            $id = $record['id'];
+            self::assertIsString($id);
+            $byId[$id] = $record;
+        }
+
+        // product-level row
+        self::assertArrayHasKey('PROD-1', $byId);
+        self::assertSame('Acme Shoe', $byId['PROD-1']['title']);
+        self::assertSame('999', $byId['PROD-1']['from_price']);
+        self::assertSame('', $byId['PROD-1']['channel_price'], 'from_price is a product-only field, channel_price is variant-only');
+
+        // variant-level row
+        self::assertArrayHasKey('VARIANT-1', $byId);
+        self::assertSame('Acme Shoe', $byId['VARIANT-1']['title']);
+        self::assertSame('999', $byId['VARIANT-1']['channel_price']);
+        self::assertSame('', $byId['VARIANT-1']['from_price']);
+    }
+
+    /**
+     * @param list<string> $fields
+     */
+    private function source(string $feedType, int $position, array $fields): FeedSourceInterface
+    {
+        $source = new FeedSource();
+        $source->setFeedType($feedType);
+        $source->setPosition($position);
+
+        foreach ($fields as $index => $name) {
+            $source->addField($this->field($name, $index));
+        }
+
+        return $source;
+    }
+
+    private function field(string $name, int $position): FeedFieldInterface
+    {
+        $field = new FeedField();
+        $field->setOutputField($name);
+        $field->setSourceType('field');
+        $field->setSourceValue($name);
+        $field->setPosition($position);
+
+        return $field;
+    }
+
+    private function generate(Feed $feed, FeedContext $context): \Setono\SyliusFeedPlugin\Generator\GenerationResult
+    {
+        $generator = self::getContainer()->get(FeedGenerator::class);
+        self::assertInstanceOf(FeedGenerator::class, $generator);
+
+        $result = $generator->generate($feed, $context);
+        $this->generatedPaths[] = $result->path;
+
+        return $result;
+    }
+
+    private function read(string $path): Reader
+    {
+        $filesystem = self::getContainer()->get('setono_sylius_feed.storage.feed_tmp');
+        self::assertInstanceOf(FilesystemOperator::class, $filesystem);
+
+        $reader = Reader::createFromString($filesystem->read($path));
+        $reader->setHeaderOffset(0);
+
+        return $reader;
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $manager = self::getContainer()->get('doctrine.orm.entity_manager');
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+
+        return $manager;
+    }
+
+    private function persist(object $entity): void
+    {
+        $manager = $this->entityManager();
+        $manager->persist($entity);
+        $manager->flush();
+    }
+
+    private function persistFixtures(): Channel
+    {
+        $currency = new Currency();
+        $currency->setCode('USD');
+
+        $locale = new Locale();
+        $locale->setCode('en_US');
+
+        $channel = new Channel();
+        $channel->setCode('web');
+        $channel->setName('Web');
+        $channel->setHostname('localhost');
+        $channel->setBaseCurrency($currency);
+        $channel->setDefaultLocale($locale);
+        $channel->addCurrency($currency);
+        $channel->addLocale($locale);
+        $channel->setTaxCalculationStrategy('order_items_based');
+        $channel->setEnabled(true);
+
+        $product = new Product();
+        $product->setCode('PROD-1');
+        $product->setEnabled(true);
+        $product->setCurrentLocale('en_US');
+        $product->setFallbackLocale('en_US');
+        $product->setName('Acme Shoe');
+        $product->setSlug('acme-shoe');
+        $product->setDescription('A very nice shoe');
+        $product->addChannel($channel);
+
+        $variant = new ProductVariant();
+        $variant->setCode('VARIANT-1');
+        $variant->setEnabled(true);
+
+        $channelPricing = new ChannelPricing();
+        $channelPricing->setChannelCode('web');
+        $channelPricing->setPrice(999);
+        $variant->addChannelPricing($channelPricing);
+
+        $product->addVariant($variant);
+
+        $manager = $this->entityManager();
+        foreach ([$currency, $locale, $channel, $product, $variant] as $entity) {
+            $manager->persist($entity);
+        }
+        $manager->flush();
+
+        return $channel;
+    }
+}

--- a/tests/Functional/ProductFeedGenerationTest.php
+++ b/tests/Functional/ProductFeedGenerationTest.php
@@ -78,11 +78,12 @@ final class ProductFeedGenerationTest extends FunctionalTestCase
 
         self::assertSame(['id', 'title', 'from_price'], $reader->getHeader());
 
-        $records = array_values(iterator_to_array($reader->getRecords()));
+        $records = $this->csvRecords($reader);
         self::assertCount(1, $records);
-        self::assertSame('PROD-1', $records[0]['id']);
-        self::assertSame('Acme Shoe', $records[0]['title']);
-        self::assertSame('999', $records[0]['from_price']);
+        $row = $records[0];
+        self::assertSame('PROD-1', $row['id']);
+        self::assertSame('Acme Shoe', $row['title']);
+        self::assertSame('999', $row['from_price']);
     }
 
     /**
@@ -116,7 +117,7 @@ final class ProductFeedGenerationTest extends FunctionalTestCase
         self::assertSame(['id', 'title', 'from_price', 'channel_price'], $header);
 
         $byId = [];
-        foreach ($reader->getRecords() as $record) {
+        foreach ($this->csvRecords($reader) as $record) {
             $id = $record['id'];
             self::assertIsString($id);
             $byId[$id] = $record;
@@ -182,6 +183,17 @@ final class ProductFeedGenerationTest extends FunctionalTestCase
         $reader->setHeaderOffset(0);
 
         return $reader;
+    }
+
+    /**
+     * Normalises league/csv records to arrays through a mixed boundary — older league/csv versions
+     * type `getRecords()` loosely (mixed), newer ones precisely, so this stays valid on both.
+     *
+     * @return list<array<int|string, mixed>>
+     */
+    private function csvRecords(Reader $reader): array
+    {
+        return array_values(array_filter(iterator_to_array($reader->getRecords()), is_array(...)));
     }
 
     private function entityManager(): EntityManagerInterface

--- a/tests/Functional/Scripting/ScriptingTest.php
+++ b/tests/Functional/Scripting/ScriptingTest.php
@@ -4,30 +4,40 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\Tests\Functional\Scripting;
 
-use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
-use Setono\SyliusFeedPlugin\Lookup\LookupInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\SyliusFeedPlugin\Model\LookupTable;
 use Setono\SyliusFeedPlugin\Scripting\ExpressionEvaluatorInterface;
 use Setono\SyliusFeedPlugin\Scripting\TwigTemplateRendererInterface;
 use Setono\SyliusFeedPlugin\Tests\Functional\FunctionalTestCase;
 
 /**
- * Proves the M4 scripting services (§10) are wired together correctly: the expression evaluator and
- * the sandboxed Twig renderer both resolve `lookup(...)` calls through the very same lookup instance
- * the container hands out elsewhere (the {@see LookupInterface} alias is a singleton). Does not touch
- * the database.
+ * Proves the M4 scripting services (§10) are wired together and resolve `lookup(...)` through the
+ * DB-backed {@see \Setono\SyliusFeedPlugin\Lookup\DatabaseLookup}: a persisted LookupTable enriches
+ * both the expression evaluator and the sandboxed Twig renderer.
  */
 final class ScriptingTest extends FunctionalTestCase
 {
+    private function persistBadges(): void
+    {
+        $table = new LookupTable();
+        $table->setCode('badges');
+        $table->setSourceType(LookupTable::SOURCE_TYPE_CSV);
+        $table->setRows(['SKU-1' => ['suffix' => 'Bestseller']]);
+
+        $registry = self::getContainer()->get('doctrine');
+        self::assertInstanceOf(ManagerRegistry::class, $registry);
+        $manager = $registry->getManagerForClass(LookupTable::class);
+        self::assertNotNull($manager);
+        $manager->persist($table);
+        $manager->flush();
+    }
+
     /**
      * @test
      */
-    public function it_shares_a_single_lookup_instance_across_the_scripting_services(): void
+    public function it_resolves_a_lookup_in_an_expression_through_the_database(): void
     {
-        $lookup = self::getContainer()->get(LookupInterface::class);
-
-        self::assertInstanceOf(InMemoryLookup::class, $lookup);
-
-        $lookup->addTable('badges', ['SKU-1' => ['suffix' => 'Bestseller']]);
+        $this->persistBadges();
 
         $evaluator = self::getContainer()->get(ExpressionEvaluatorInterface::class);
         self::assertInstanceOf(ExpressionEvaluatorInterface::class, $evaluator);
@@ -41,12 +51,9 @@ final class ScriptingTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_renders_a_template_that_looks_up_a_shared_table(): void
+    public function it_resolves_a_lookup_in_a_sandboxed_twig_template_through_the_database(): void
     {
-        $lookup = self::getContainer()->get(LookupInterface::class);
-        self::assertInstanceOf(InMemoryLookup::class, $lookup);
-
-        $lookup->addTable('badges', ['SKU-1' => ['suffix' => 'Bestseller']]);
+        $this->persistBadges();
 
         $renderer = self::getContainer()->get(TwigTemplateRendererInterface::class);
         self::assertInstanceOf(TwigTemplateRendererInterface::class, $renderer);

--- a/tests/Unit/Controller/Admin/RefreshLookupTableActionTest.php
+++ b/tests/Unit/Controller/Admin/RefreshLookupTableActionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Controller\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Controller\Admin\RefreshLookupTableAction;
+use Setono\SyliusFeedPlugin\Lookup\LookupTableRefresherInterface;
+use Setono\SyliusFeedPlugin\Model\LookupTable;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+final class RefreshLookupTableActionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_refreshes_the_table_and_redirects_to_the_grid(): void
+    {
+        $table = new LookupTable();
+        $table->setCode('badges');
+
+        $repository = $this->prophesize(LookupTableRepositoryInterface::class);
+        $repository->find(1)->willReturn($table);
+
+        $refresher = $this->prophesize(LookupTableRefresherInterface::class);
+        $refresher->refresh($table)->shouldBeCalledOnce();
+
+        $router = $this->prophesize(RouterInterface::class);
+        $router->generate('setono_sylius_feed_admin_lookup_table_index')->willReturn('/admin/lookup-tables/');
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+
+        $response = (new RefreshLookupTableAction($repository->reveal(), $refresher->reveal(), $router->reveal()))($request, 1);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/admin/lookup-tables/', $response->getTargetUrl());
+
+        /** @var array<string, list<string>> $flashes */
+        $flashes = $session->getFlashBag()->peekAll();
+        self::assertContains('setono_sylius_feed.lookup_table.refreshed', $flashes['success'] ?? []);
+    }
+
+    /**
+     * @test
+     */
+    public function it_404s_for_a_missing_table(): void
+    {
+        $repository = $this->prophesize(LookupTableRepositoryInterface::class);
+        $repository->find(999)->willReturn(null);
+
+        $refresher = $this->prophesize(LookupTableRefresherInterface::class);
+        $refresher->refresh(Argument::cetera())->shouldNotBeCalled();
+
+        $this->expectException(NotFoundHttpException::class);
+
+        (new RefreshLookupTableAction($repository->reveal(), $refresher->reveal(), $this->prophesize(RouterInterface::class)->reveal()))(new Request(), 999);
+    }
+}

--- a/tests/Unit/Format/GenericXmlFormatTest.php
+++ b/tests/Unit/Format/GenericXmlFormatTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Format;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Format\GenericXmlFormat;
+use Setono\SyliusFeedPlugin\Writer\XmlWriterConfig;
+
+final class GenericXmlFormatTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        $format = new GenericXmlFormat();
+
+        self::assertSame('generic_xml', $format->getCode());
+        self::assertSame('xml', $format->getWriter());
+        self::assertSame([], $format->getRequiredFields());
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_the_xml_structural_config(): void
+    {
+        $config = (new GenericXmlFormat())->getConfig();
+
+        self::assertInstanceOf(XmlWriterConfig::class, $config);
+        self::assertSame('feed', $config->rootElement);
+        self::assertSame('item', $config->itemElement);
+    }
+}

--- a/tests/Unit/Format/PartnerAdsFormatTest.php
+++ b/tests/Unit/Format/PartnerAdsFormatTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Format;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Format\PartnerAdsFormat;
+use Setono\SyliusFeedPlugin\Writer\XmlWriterConfig;
+
+final class PartnerAdsFormatTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        $format = new PartnerAdsFormat();
+
+        self::assertSame('partner_ads', $format->getCode());
+        self::assertSame('xml', $format->getWriter());
+        self::assertSame([], $format->getRequiredFields());
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_the_xml_structural_config(): void
+    {
+        $config = (new PartnerAdsFormat())->getConfig();
+
+        self::assertInstanceOf(XmlWriterConfig::class, $config);
+        self::assertSame('produkter', $config->rootElement);
+        self::assertSame('produkt', $config->itemElement);
+    }
+}

--- a/tests/Unit/Generator/FeedGeneratorMemoryTest.php
+++ b/tests/Unit/Generator/FeedGeneratorMemoryTest.php
@@ -104,6 +104,7 @@ final class FeedGeneratorMemoryTest extends TestCase
                 new OperatorRegistry([new IsTrue()]),
                 new ExpressionEvaluator(new InMemoryLookup()),
                 new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), new InMemoryLookup()),
+                new NullLookupReferenceResolver(),
             ),
             new RequiredFieldsValidator(),
             new EventDispatcher(),

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -141,7 +141,7 @@ final class FeedGeneratorTest extends TestCase
         self::assertSame(2, $result->itemCount);
 
         $csv = $this->filesystem->read($result->path);
-        $rows = array_values(iterator_to_array(Reader::createFromString($csv)->getRecords()));
+        $rows = [...Reader::createFromString($csv)->getRecords()];
 
         self::assertCount(3, $rows, 'header + two item rows');
         self::assertSame(['id', 'title', 'availability'], $rows[0]);
@@ -178,7 +178,7 @@ final class FeedGeneratorTest extends TestCase
      */
     private function csvRecords(Reader $reader): array
     {
-        return array_values(array_filter(iterator_to_array($reader->getRecords()), is_array(...)));
+        return array_values(array_filter([...$reader->getRecords()], is_array(...)));
     }
 
     /**

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\Tests\Unit\Generator;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use League\Csv\Reader;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
 use Setono\SyliusFeedPlugin\Filter\FilterSet;
+use Setono\SyliusFeedPlugin\Format\CsvFormat;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Format\GoogleRssFormat;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
@@ -24,6 +26,8 @@ use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
+use Setono\SyliusFeedPlugin\Model\FeedField;
+use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
 use Setono\SyliusFeedPlugin\Operator\IsTrue;
@@ -38,6 +42,7 @@ use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
 use Setono\SyliusFeedPlugin\Transformation\Truncate;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
+use Setono\SyliusFeedPlugin\Writer\CsvWriter;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
 use Setono\SyliusFeedPlugin\Writer\XmlWriter;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -103,6 +108,54 @@ final class FeedGeneratorTest extends TestCase
     }
 
     /**
+     * A CSV feed whose mapping comes from admin-configured FeedField rows: one header row that is
+     * the union of the output fields (in row order) followed by one row per item, cells keyed by
+     * the header.
+     *
+     * @test
+     */
+    public function it_generates_a_csv_feed_with_a_union_header(): void
+    {
+        $source = $this->prophesize(FeedSourceInterface::class);
+        $source->getFeedType()->willReturn('product_variant');
+        $source->getPosition()->willReturn(0);
+        $source->getFilters()->willReturn(new ArrayCollection());
+        $source->getFields()->willReturn(new ArrayCollection([
+            $this->feedField('id', 'id', 0),
+            $this->feedField('title', 'title', 1),
+            $this->feedField('availability', 'availability', 2),
+        ]));
+
+        $feed = $this->prophesize(FeedInterface::class);
+        $feed->getCode()->willReturn('google');
+        $feed->getFormat()->willReturn('csv');
+        $feed->getSources()->willReturn(new ArrayCollection([$source->reveal()]));
+
+        $result = $this->createGenerator()->generate($feed->reveal(), new FeedContext($this->channel(), 'en_US', 'USD'));
+
+        self::assertSame('google/web_en_us_usd.csv', $result->path);
+        self::assertSame(2, $result->itemCount);
+
+        $csv = $this->filesystem->read($result->path);
+        $rows = array_values(iterator_to_array(Reader::createFromString($csv)->getRecords()));
+
+        self::assertCount(3, $rows, 'header + two item rows');
+        self::assertSame(['id', 'title', 'availability'], $rows[0]);
+        self::assertSame(['SKU-1', 'Acme Shoe', 'in_stock'], $rows[1]);
+    }
+
+    private function feedField(string $outputField, string $sourceField, int $position): FeedFieldInterface
+    {
+        $field = new FeedField();
+        $field->setOutputField($outputField);
+        $field->setSourceType('field');
+        $field->setSourceValue($sourceField);
+        $field->setPosition($position);
+
+        return $field;
+    }
+
+    /**
      * With no matching preset there are no field mappings, so every item lacks the required output
      * fields and is excluded — the feed is still written, just empty.
      *
@@ -132,9 +185,11 @@ final class FeedGeneratorTest extends TestCase
 
         $formatRegistry = $this->prophesize(FormatRegistryInterface::class);
         $formatRegistry->get('google_rss')->willReturn(new GoogleRssFormat());
+        $formatRegistry->get('csv')->willReturn(new CsvFormat());
 
         $writerRegistry = $this->prophesize(FeedWriterRegistryInterface::class);
         $writerRegistry->get('xml')->willReturn(new XmlWriter());
+        $writerRegistry->get('csv')->willReturn(new CsvWriter());
 
         $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->getContext()->willReturn(new RequestContext());
@@ -246,7 +301,7 @@ final class FeedGeneratorTest extends TestCase
         return $channel->reveal();
     }
 
-    private function feed(): FeedInterface
+    private function feed(string $format = 'google_rss'): FeedInterface
     {
         $source = $this->prophesize(FeedSourceInterface::class);
         $source->getFeedType()->willReturn('product_variant');
@@ -256,7 +311,7 @@ final class FeedGeneratorTest extends TestCase
 
         $feed = $this->prophesize(FeedInterface::class);
         $feed->getCode()->willReturn('google');
-        $feed->getFormat()->willReturn('google_rss');
+        $feed->getFormat()->willReturn($format);
         $feed->getSources()->willReturn(new ArrayCollection([$source->reveal()]));
 
         return $feed->reveal();

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -163,11 +163,22 @@ final class FeedGeneratorTest extends TestCase
         self::assertContains('availability', $reader->getHeader());
         self::assertContains('price', $reader->getHeader());
 
-        $records = array_values(iterator_to_array($reader->getRecords()));
+        $records = $this->csvRecords($reader);
         $row = $records[0];
         self::assertSame('SKU-1', $row['id']);
         self::assertSame('in stock', $row['availability']);
         self::assertSame('9.99 USD', $row['price']);
+    }
+
+    /**
+     * Normalises league/csv records to arrays through a mixed boundary — older league/csv versions
+     * type `getRecords()` loosely (mixed), newer ones precisely, so this stays valid on both.
+     *
+     * @return list<array<int|string, mixed>>
+     */
+    private function csvRecords(Reader $reader): array
+    {
+        return array_values(array_filter(iterator_to_array($reader->getRecords()), is_array(...)));
     }
 
     /**

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -252,6 +252,7 @@ final class FeedGeneratorTest extends TestCase
                 new OperatorRegistry([new IsTrue()]),
                 new ExpressionEvaluator(new InMemoryLookup()),
                 new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), new InMemoryLookup()),
+                new NullLookupReferenceResolver(),
             ),
             new RequiredFieldsValidator(),
             new EventDispatcher(),

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -18,6 +18,7 @@ use Setono\SyliusFeedPlugin\Filter\FilterSet;
 use Setono\SyliusFeedPlugin\Format\CsvFormat;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Format\GoogleRssFormat;
+use Setono\SyliusFeedPlugin\Format\PartnerAdsFormat;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
@@ -26,6 +27,8 @@ use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
+use Setono\SyliusFeedPlugin\MappingPreset\MetaMappingPreset;
+use Setono\SyliusFeedPlugin\MappingPreset\PartnerAdsMappingPreset;
 use Setono\SyliusFeedPlugin\Model\FeedField;
 use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
@@ -41,6 +44,7 @@ use Setono\SyliusFeedPlugin\Transformation\StripTags;
 use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
 use Setono\SyliusFeedPlugin\Transformation\Truncate;
+use Setono\SyliusFeedPlugin\Transformation\ValueMap;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
 use Setono\SyliusFeedPlugin\Writer\CsvWriter;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
@@ -144,6 +148,48 @@ final class FeedGeneratorTest extends TestCase
         self::assertSame(['SKU-1', 'Acme Shoe', 'in_stock'], $rows[1]);
     }
 
+    /**
+     * Acceptance: the same catalog renders as a valid Meta CSV (with Meta's space-separated
+     * availability) purely by choosing the Meta preset — no code changes.
+     *
+     * @test
+     */
+    public function it_generates_a_valid_meta_csv_from_the_catalog(): void
+    {
+        $result = $this->createGenerator([new MetaMappingPreset()])->generate($this->feed('csv'), new FeedContext($this->channel(), 'en_US', 'USD'));
+
+        $reader = Reader::createFromString($this->filesystem->read($result->path));
+        $reader->setHeaderOffset(0);
+        self::assertContains('availability', $reader->getHeader());
+        self::assertContains('price', $reader->getHeader());
+
+        $records = array_values(iterator_to_array($reader->getRecords()));
+        $row = $records[0];
+        self::assertSame('SKU-1', $row['id']);
+        self::assertSame('in stock', $row['availability']);
+        self::assertSame('9.99 USD', $row['price']);
+    }
+
+    /**
+     * Acceptance: the same catalog renders as a valid Partner-ads XML (Danish element names, its
+     * own root/item) purely by choosing the Partner-ads preset — no code changes.
+     *
+     * @test
+     */
+    public function it_generates_a_valid_partner_ads_xml_from_the_catalog(): void
+    {
+        $result = $this->createGenerator([new PartnerAdsMappingPreset()])->generate($this->feed('partner_ads'), new FeedContext($this->channel(), 'en_US', 'USD'));
+
+        $xml = $this->filesystem->read($result->path);
+        self::assertTrue((new \DOMDocument())->loadXML($xml), 'The Partner-ads feed must be well-formed XML');
+        self::assertStringContainsString('<produkter>', $xml);
+        self::assertSame(2, substr_count($xml, '<produkt>'));
+        self::assertStringContainsString('<produktid>SKU-1</produktid>', $xml);
+        self::assertStringContainsString('<produktnavn>Acme Shoe</produktnavn>', $xml);
+        self::assertStringContainsString('<nypris>9.99 USD</nypris>', $xml);
+        self::assertStringContainsString('<VareURL>https://example.com/products/acme-shoe</VareURL>', $xml);
+    }
+
     private function feedField(string $outputField, string $sourceField, int $position): FeedFieldInterface
     {
         $field = new FeedField();
@@ -186,6 +232,7 @@ final class FeedGeneratorTest extends TestCase
         $formatRegistry = $this->prophesize(FormatRegistryInterface::class);
         $formatRegistry->get('google_rss')->willReturn(new GoogleRssFormat());
         $formatRegistry->get('csv')->willReturn(new CsvFormat());
+        $formatRegistry->get('partner_ads')->willReturn(new PartnerAdsFormat());
 
         $writerRegistry = $this->prophesize(FeedWriterRegistryInterface::class);
         $writerRegistry->get('xml')->willReturn(new XmlWriter());
@@ -200,7 +247,7 @@ final class FeedGeneratorTest extends TestCase
             $formatRegistry->reveal(),
             $writerRegistry->reveal(),
             new FieldMappingEvaluator(
-                new TransformationChain(new TransformationRegistry([new Truncate(), new StripTags(), new MoneyFormat()])),
+                new TransformationChain(new TransformationRegistry([new Truncate(), new StripTags(), new MoneyFormat(), new ValueMap()])),
                 new ReferenceResolver(),
                 new OperatorRegistry([new IsTrue()]),
                 new ExpressionEvaluator(new InMemoryLookup()),

--- a/tests/Unit/Generator/FieldMappingEvaluatorTest.php
+++ b/tests/Unit/Generator/FieldMappingEvaluatorTest.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\Tests\Unit\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
 use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolver;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\Model\LookupTable;
 use Setono\SyliusFeedPlugin\Operator\Equals;
 use Setono\SyliusFeedPlugin\Operator\IsTrue;
 use Setono\SyliusFeedPlugin\Operator\OperatorRegistry;
 use Setono\SyliusFeedPlugin\Reference\ReferenceResolver;
+use Setono\SyliusFeedPlugin\Repository\LookupTableRepositoryInterface;
 use Setono\SyliusFeedPlugin\Scripting\ExpressionEvaluator;
 use Setono\SyliusFeedPlugin\Scripting\FeedTemplateSecurityPolicy;
 use Setono\SyliusFeedPlugin\Scripting\SandboxedTwigRenderer;
@@ -30,6 +35,8 @@ use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
  */
 final class FieldMappingEvaluatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -155,7 +162,32 @@ final class FieldMappingEvaluatorTest extends TestCase
         self::assertSame('Acme Shoe Bestseller', $item->get('g:title'));
     }
 
-    private function evaluator(?InMemoryLookup $lookup = null): FieldMappingEvaluator
+    /**
+     * The exact §10.1 case: a title joined with a per-item lookup value resolved via a
+     * `lookup:{code}:{column}` source reference, keyed off the table's joinField.
+     *
+     * @test
+     */
+    public function it_resolves_a_lookup_source_reference_via_the_join_field(): void
+    {
+        $table = new LookupTable();
+        $table->setCode('badges');
+        $table->setJoinField('code');
+        $table->setRows(['SKU-1' => ['badge' => 'Bestseller']]);
+
+        $repository = $this->prophesize(LookupTableRepositoryInterface::class);
+        $repository->findOneByCode('badges')->willReturn($table);
+
+        $item = $this->item();
+        $mapping = FieldMapping::field('g:title', 'title')->transform(Concat::of(['value', 'lookup:badges:badge'], ' '));
+
+        $this->evaluator(null, new LookupReferenceResolver($repository->reveal()))
+            ->apply($item, [$mapping], $this->fields(['title' => 'Acme Shoe', 'code' => 'SKU-1']));
+
+        self::assertSame('Acme Shoe Bestseller', $item->get('g:title'));
+    }
+
+    private function evaluator(?InMemoryLookup $lookup = null, ?LookupReferenceResolverInterface $lookupReferenceResolver = null): FieldMappingEvaluator
     {
         $lookup ??= new InMemoryLookup();
         $referenceResolver = new ReferenceResolver();
@@ -166,6 +198,7 @@ final class FieldMappingEvaluatorTest extends TestCase
             new OperatorRegistry([new IsTrue(), new Equals()]),
             new ExpressionEvaluator($lookup),
             new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), $lookup),
+            $lookupReferenceResolver ?? new NullLookupReferenceResolver(),
         );
     }
 

--- a/tests/Unit/Generator/NullLookupReferenceResolver.php
+++ b/tests/Unit/Generator/NullLookupReferenceResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Generator;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
+
+/**
+ * A no-op lookup reference resolver for generator tests that don't exercise `lookup:` references.
+ */
+final class NullLookupReferenceResolver implements LookupReferenceResolverInterface
+{
+    public function supports(string $reference): bool
+    {
+        return false;
+    }
+
+    public function resolve(string $reference, object $entity, FeedContext $context, array $availableFields): mixed
+    {
+        return null;
+    }
+}

--- a/tests/Unit/Lookup/CsvLookupSourceTest.php
+++ b/tests/Unit/Lookup/CsvLookupSourceTest.php
@@ -27,7 +27,7 @@ final class CsvLookupSourceTest extends TestCase
         $filesystem->readStream('uploads/badges.csv')->willReturn($stream);
 
         $source = new CsvLookupSource($filesystem->reveal());
-        $rows = iterator_to_array($source->fetch(['path' => 'uploads/badges.csv']), false);
+        $rows = [...$source->fetch(['path' => 'uploads/badges.csv'])];
 
         self::assertSame('csv', $source->getType());
         self::assertSame([
@@ -43,6 +43,6 @@ final class CsvLookupSourceTest extends TestCase
     {
         $source = new CsvLookupSource($this->prophesize(FilesystemOperator::class)->reveal());
 
-        self::assertSame([], iterator_to_array($source->fetch([]), false));
+        self::assertSame([], [...$source->fetch([])]);
     }
 }

--- a/tests/Unit/Lookup/CsvLookupSourceTest.php
+++ b/tests/Unit/Lookup/CsvLookupSourceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Lookup;
+
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Lookup\CsvLookupSource;
+
+final class CsvLookupSourceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_parses_rows_keyed_by_the_header(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, "product_code,gtin,badge\nSKU-1,111,Bestseller\nSKU-2,222,New\n");
+        rewind($stream);
+
+        $filesystem = $this->prophesize(FilesystemOperator::class);
+        $filesystem->readStream('uploads/badges.csv')->willReturn($stream);
+
+        $source = new CsvLookupSource($filesystem->reveal());
+        $rows = iterator_to_array($source->fetch(['path' => 'uploads/badges.csv']), false);
+
+        self::assertSame('csv', $source->getType());
+        self::assertSame([
+            ['product_code' => 'SKU-1', 'gtin' => '111', 'badge' => 'Bestseller'],
+            ['product_code' => 'SKU-2', 'gtin' => '222', 'badge' => 'New'],
+        ], $rows);
+    }
+
+    /**
+     * @test
+     */
+    public function it_yields_nothing_without_a_path(): void
+    {
+        $source = new CsvLookupSource($this->prophesize(FilesystemOperator::class)->reveal());
+
+        self::assertSame([], iterator_to_array($source->fetch([]), false));
+    }
+}

--- a/tests/Unit/Lookup/LookupTableRefresherTest.php
+++ b/tests/Unit/Lookup/LookupTableRefresherTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Lookup;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\LoggerInterface;
+use Setono\SyliusFeedPlugin\Lookup\LookupSourceInterface;
+use Setono\SyliusFeedPlugin\Lookup\LookupSourceRegistryInterface;
+use Setono\SyliusFeedPlugin\Lookup\LookupTableRefresher;
+use Setono\SyliusFeedPlugin\Model\LookupTable;
+
+final class LookupTableRefresherTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function table(): LookupTable
+    {
+        $table = new LookupTable();
+        $table->setCode('badges');
+        $table->setSourceType('csv');
+        $table->setKeyColumn('product_code');
+
+        return $table;
+    }
+
+    /**
+     * @test
+     */
+    public function it_imports_rows_keyed_by_the_key_column_and_stamps_refreshed_at(): void
+    {
+        $source = new class() implements LookupSourceInterface {
+            public function getType(): string
+            {
+                return 'csv';
+            }
+
+            public function fetch(array $sourceConfig): iterable
+            {
+                yield ['product_code' => 'SKU-1', 'gtin' => '111'];
+                yield ['product_code' => 'SKU-2', 'gtin' => '222'];
+            }
+        };
+
+        $registry = $this->prophesize(LookupSourceRegistryInterface::class);
+        $registry->has('csv')->willReturn(true);
+        $registry->get('csv')->willReturn($source);
+
+        $manager = $this->prophesize(EntityManagerInterface::class);
+        $manager->flush()->shouldBeCalledOnce();
+
+        $doctrine = $this->prophesize(ManagerRegistry::class);
+        $doctrine->getManagerForClass(LookupTable::class)->willReturn($manager->reveal());
+
+        $table = $this->table();
+        (new LookupTableRefresher($doctrine->reveal(), $registry->reveal(), $this->prophesize(LoggerInterface::class)->reveal()))->refresh($table);
+
+        self::assertSame([
+            'SKU-1' => ['product_code' => 'SKU-1', 'gtin' => '111'],
+            'SKU-2' => ['product_code' => 'SKU-2', 'gtin' => '222'],
+        ], $table->getRows());
+        self::assertNotNull($table->getRefreshedAt());
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_the_last_good_rows_when_the_source_fails(): void
+    {
+        $source = new class() implements LookupSourceInterface {
+            public function getType(): string
+            {
+                return 'csv';
+            }
+
+            public function fetch(array $sourceConfig): iterable
+            {
+                throw new \RuntimeException('remote outage');
+            }
+        };
+
+        $registry = $this->prophesize(LookupSourceRegistryInterface::class);
+        $registry->has('csv')->willReturn(true);
+        $registry->get('csv')->willReturn($source);
+
+        $manager = $this->prophesize(EntityManagerInterface::class);
+        $manager->flush()->shouldNotBeCalled();
+
+        $doctrine = $this->prophesize(ManagerRegistry::class);
+        $doctrine->getManagerForClass(Argument::any())->willReturn($manager->reveal());
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger->warning(Argument::containingString('keeping the last-good'), Argument::cetera())->shouldBeCalled();
+
+        $lastGoodAt = new \DateTimeImmutable('2020-01-01 00:00:00');
+        $table = $this->table();
+        $table->setRows(['OLD' => ['product_code' => 'OLD', 'gtin' => '999']]);
+        $table->setRefreshedAt($lastGoodAt);
+
+        (new LookupTableRefresher($doctrine->reveal(), $registry->reveal(), $logger->reveal()))->refresh($table);
+
+        self::assertSame(['OLD' => ['product_code' => 'OLD', 'gtin' => '999']], $table->getRows());
+        self::assertSame($lastGoodAt, $table->getRefreshedAt());
+    }
+}

--- a/tests/Unit/Lookup/UrlLookupSourceTest.php
+++ b/tests/Unit/Lookup/UrlLookupSourceTest.php
@@ -17,7 +17,7 @@ final class UrlLookupSourceTest extends TestCase
         $url = 'data://text/csv;base64,' . base64_encode("product_code,gtin\nSKU-1,111\n");
 
         $source = new UrlLookupSource();
-        $rows = iterator_to_array($source->fetch(['url' => $url]), false);
+        $rows = [...$source->fetch(['url' => $url])];
 
         self::assertSame('url', $source->getType());
         self::assertSame([['product_code' => 'SKU-1', 'gtin' => '111']], $rows);
@@ -30,7 +30,7 @@ final class UrlLookupSourceTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        iterator_to_array((new UrlLookupSource())->fetch(['url' => 'file:///does/not/exist/lookup.csv']), false);
+        [...(new UrlLookupSource())->fetch(['url' => 'file:///does/not/exist/lookup.csv'])];
     }
 
     /**
@@ -38,6 +38,6 @@ final class UrlLookupSourceTest extends TestCase
      */
     public function it_yields_nothing_without_a_url(): void
     {
-        self::assertSame([], iterator_to_array((new UrlLookupSource())->fetch([]), false));
+        self::assertSame([], [...(new UrlLookupSource())->fetch([])]);
     }
 }

--- a/tests/Unit/Lookup/UrlLookupSourceTest.php
+++ b/tests/Unit/Lookup/UrlLookupSourceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Lookup;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Lookup\UrlLookupSource;
+
+final class UrlLookupSourceTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_downloads_and_parses_csv_from_a_url(): void
+    {
+        $url = 'data://text/csv;base64,' . base64_encode("product_code,gtin\nSKU-1,111\n");
+
+        $source = new UrlLookupSource();
+        $rows = iterator_to_array($source->fetch(['url' => $url]), false);
+
+        self::assertSame('url', $source->getType());
+        self::assertSame([['product_code' => 'SKU-1', 'gtin' => '111']], $rows);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_the_download_fails(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        iterator_to_array((new UrlLookupSource())->fetch(['url' => 'file:///does/not/exist/lookup.csv']), false);
+    }
+
+    /**
+     * @test
+     */
+    public function it_yields_nothing_without_a_url(): void
+    {
+        self::assertSame([], iterator_to_array((new UrlLookupSource())->fetch([]), false));
+    }
+}

--- a/tests/Unit/MappingPreset/BingMappingPresetTest.php
+++ b/tests/Unit/MappingPreset/BingMappingPresetTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\MappingPreset;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Mapping\SourceType;
+use Setono\SyliusFeedPlugin\MappingPreset\BingMappingPreset;
+use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
+
+final class BingMappingPresetTest extends TestCase
+{
+    private BingMappingPreset $preset;
+
+    protected function setUp(): void
+    {
+        $this->preset = new BingMappingPreset();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('bing', $this->preset->getCode());
+        self::assertSame('setono_sylius_feed.mapping_preset.bing', $this->preset->getLabel());
+        self::assertSame('google_rss', $this->preset->getFormat());
+        self::assertTrue($this->preset->supports('product_variant'));
+        self::assertFalse($this->preset->supports('order'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_the_required_google_vocabulary_fields(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        foreach (['g:id', 'g:title', 'g:description', 'g:link', 'g:image_link', 'g:availability', 'g:price'] as $required) {
+            self::assertArrayHasKey($required, $byOutput, sprintf('Missing required field "%s"', $required));
+        }
+
+        self::assertSame(SourceType::LITERAL, $byOutput['g:condition']->getSourceType());
+        self::assertNotNull($byOutput['g:item_group_id']->getCondition());
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_non_core_fields_as_requiring_input(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertTrue($byOutput['g:brand']->getRequiresInput());
+        self::assertTrue($byOutput['g:gtin']->getRequiresInput());
+        self::assertTrue($byOutput['g:google_product_category']->getRequiresInput());
+        self::assertFalse($byOutput['g:id']->getRequiresInput());
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_same_mapping_as_google_shopping(): void
+    {
+        $normalize = static fn (FieldMapping $m): array => [
+            'outputField' => $m->getOutputField(),
+            'sourceType' => $m->getSourceType(),
+            'sourceValue' => $m->getSourceValue(),
+            'requiresInput' => $m->getRequiresInput(),
+            'condition' => $m->getCondition(),
+        ];
+
+        self::assertEquals(
+            array_map($normalize, (new GoogleShoppingMappingPreset())->getMapping()),
+            array_map($normalize, $this->preset->getMapping()),
+        );
+    }
+}

--- a/tests/Unit/MappingPreset/MetaMappingPresetTest.php
+++ b/tests/Unit/MappingPreset/MetaMappingPresetTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\MappingPreset;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\MappingPreset\MetaMappingPreset;
+use Setono\SyliusFeedPlugin\Transformation\ValueMap;
+
+final class MetaMappingPresetTest extends TestCase
+{
+    private MetaMappingPreset $preset;
+
+    protected function setUp(): void
+    {
+        $this->preset = new MetaMappingPreset();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('meta', $this->preset->getCode());
+        self::assertSame('setono_sylius_feed.mapping_preset.meta', $this->preset->getLabel());
+        self::assertSame('csv', $this->preset->getFormat());
+        self::assertTrue($this->preset->supports('product_variant'));
+        self::assertFalse($this->preset->supports('order'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_the_meta_catalog_columns(): void
+    {
+        $mapping = $this->preset->getMapping();
+        self::assertNotEmpty($mapping);
+
+        $outputFields = array_map(static fn (FieldMapping $m): string => $m->getOutputField(), $mapping);
+
+        self::assertSame([
+            'id',
+            'title',
+            'description',
+            'availability',
+            'condition',
+            'price',
+            'link',
+            'image_link',
+            'additional_image_link',
+            'item_group_id',
+            'brand',
+        ], $outputFields);
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_availability_via_a_value_map_using_meta_vocabulary(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        $transformations = $byOutput['availability']->getTransformations();
+        self::assertNotEmpty($transformations);
+        self::assertSame(ValueMap::TYPE, $transformations[0]->getType());
+        self::assertSame([
+            'in_stock' => 'in stock',
+            'out_of_stock' => 'out of stock',
+            'preorder' => 'available for order',
+            'backorder' => 'available for order',
+        ], $transformations[0]->getParams()['map']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_non_core_fields_as_requiring_input(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertTrue($byOutput['brand']->getRequiresInput());
+        self::assertFalse($byOutput['id']->getRequiresInput());
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_maps_item_group_id_for_configurable_items(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertNotNull($byOutput['item_group_id']->getCondition());
+    }
+}

--- a/tests/Unit/MappingPreset/PartnerAdsMappingPresetTest.php
+++ b/tests/Unit/MappingPreset/PartnerAdsMappingPresetTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\MappingPreset;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\MappingPreset\PartnerAdsMappingPreset;
+
+final class PartnerAdsMappingPresetTest extends TestCase
+{
+    private PartnerAdsMappingPreset $preset;
+
+    protected function setUp(): void
+    {
+        $this->preset = new PartnerAdsMappingPreset();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('partner_ads', $this->preset->getCode());
+        self::assertSame('setono_sylius_feed.mapping_preset.partner_ads', $this->preset->getLabel());
+        self::assertSame('partner_ads', $this->preset->getFormat());
+        self::assertTrue($this->preset->supports('product_variant'));
+        self::assertFalse($this->preset->supports('order'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_the_danish_partner_ads_columns(): void
+    {
+        $mapping = $this->preset->getMapping();
+        self::assertNotEmpty($mapping);
+
+        $outputFields = array_map(static fn (FieldMapping $m): string => $m->getOutputField(), $mapping);
+
+        self::assertSame([
+            'produktid',
+            'produktnavn',
+            'beskrivelse',
+            'nypris',
+            'glpris',
+            'VareURL',
+            'BilledURL',
+            'brand',
+            'køn',
+        ], $outputFields);
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_maps_the_original_price_when_on_sale(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertNotNull($byOutput['glpris']->getCondition());
+        self::assertNull($byOutput['nypris']->getCondition());
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_non_core_fields_as_requiring_input(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertTrue($byOutput['brand']->getRequiresInput());
+        self::assertTrue($byOutput['køn']->getRequiresInput());
+        self::assertFalse($byOutput['produktid']->getRequiresInput());
+    }
+}

--- a/tests/Unit/MappingPreset/PinterestMappingPresetTest.php
+++ b/tests/Unit/MappingPreset/PinterestMappingPresetTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\MappingPreset;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Mapping\SourceType;
+use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
+use Setono\SyliusFeedPlugin\MappingPreset\PinterestMappingPreset;
+
+final class PinterestMappingPresetTest extends TestCase
+{
+    private PinterestMappingPreset $preset;
+
+    protected function setUp(): void
+    {
+        $this->preset = new PinterestMappingPreset();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('pinterest', $this->preset->getCode());
+        self::assertSame('setono_sylius_feed.mapping_preset.pinterest', $this->preset->getLabel());
+        self::assertSame('google_rss', $this->preset->getFormat());
+        self::assertTrue($this->preset->supports('product_variant'));
+        self::assertFalse($this->preset->supports('order'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_the_required_google_vocabulary_fields(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        foreach (['g:id', 'g:title', 'g:description', 'g:link', 'g:image_link', 'g:availability', 'g:price'] as $required) {
+            self::assertArrayHasKey($required, $byOutput, sprintf('Missing required field "%s"', $required));
+        }
+
+        self::assertSame(SourceType::LITERAL, $byOutput['g:condition']->getSourceType());
+        self::assertNotNull($byOutput['g:item_group_id']->getCondition());
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_non_core_fields_as_requiring_input(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertTrue($byOutput['g:brand']->getRequiresInput());
+        self::assertTrue($byOutput['g:gtin']->getRequiresInput());
+        self::assertTrue($byOutput['g:google_product_category']->getRequiresInput());
+        self::assertFalse($byOutput['g:id']->getRequiresInput());
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_same_mapping_as_google_shopping(): void
+    {
+        $normalize = static fn (FieldMapping $m): array => [
+            'outputField' => $m->getOutputField(),
+            'sourceType' => $m->getSourceType(),
+            'sourceValue' => $m->getSourceValue(),
+            'requiresInput' => $m->getRequiresInput(),
+            'condition' => $m->getCondition(),
+        ];
+
+        self::assertEquals(
+            array_map($normalize, (new GoogleShoppingMappingPreset())->getMapping()),
+            array_map($normalize, $this->preset->getMapping()),
+        );
+    }
+}

--- a/tests/Unit/MappingPreset/TikTokMappingPresetTest.php
+++ b/tests/Unit/MappingPreset/TikTokMappingPresetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\MappingPreset;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\MappingPreset\TikTokMappingPreset;
+
+final class TikTokMappingPresetTest extends TestCase
+{
+    private TikTokMappingPreset $preset;
+
+    protected function setUp(): void
+    {
+        $this->preset = new TikTokMappingPreset();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('tiktok', $this->preset->getCode());
+        self::assertSame('setono_sylius_feed.mapping_preset.tiktok', $this->preset->getLabel());
+        self::assertSame('csv', $this->preset->getFormat());
+        self::assertTrue($this->preset->supports('product_variant'));
+        self::assertFalse($this->preset->supports('order'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_the_tiktok_catalog_columns(): void
+    {
+        $mapping = $this->preset->getMapping();
+        self::assertNotEmpty($mapping);
+
+        $outputFields = array_map(static fn (FieldMapping $m): string => $m->getOutputField(), $mapping);
+
+        self::assertSame([
+            'sku_id',
+            'title',
+            'description',
+            'availability',
+            'price',
+            'product_page_url',
+            'image_link',
+            'brand',
+        ], $outputFields);
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_sku_id_and_product_page_url_from_id_and_link(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertSame('id', $byOutput['sku_id']->getSourceValue());
+        self::assertSame('link', $byOutput['product_page_url']->getSourceValue());
+    }
+
+    /**
+     * @test
+     */
+    public function it_flags_non_core_fields_as_requiring_input(): void
+    {
+        $byOutput = [];
+        foreach ($this->preset->getMapping() as $mapping) {
+            $byOutput[$mapping->getOutputField()] = $mapping;
+        }
+
+        self::assertTrue($byOutput['brand']->getRequiresInput());
+        self::assertFalse($byOutput['sku_id']->getRequiresInput());
+    }
+}

--- a/tests/Unit/ValueResolver/Product/FromPriceResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/FromPriceResolverTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\ValueResolver\Product;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Currency\ContextCurrencyConverter;
+use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\ValueResolver\Product\FromPriceResolver;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+
+final class FromPriceResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private FromPriceResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new FromPriceResolver(new ContextCurrencyConverter($this->prophesize(CurrencyConverterInterface::class)->reveal()));
+    }
+
+    private function variant(ChannelInterface $channel, ?int $price, bool $enabled = true): ProductVariantInterface
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->isEnabled()->willReturn($enabled);
+
+        $channelPricing = null;
+        if (null !== $price) {
+            $pricing = $this->prophesize(ChannelPricingInterface::class);
+            $pricing->getPrice()->willReturn($price);
+            $channelPricing = $pricing->reveal();
+        }
+
+        $variant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
+
+        return $variant->reveal();
+    }
+
+    /**
+     * @param list<ProductVariantInterface> $variants
+     */
+    private function product(array $variants): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getVariants()->willReturn(new ArrayCollection($variants));
+
+        return $product->reveal();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('from_price', $this->resolver->getName());
+        self::assertSame('setono_sylius_feed.value_resolver.from_price', $this->resolver->getLabel());
+        self::assertSame(FieldType::MONEY, $this->resolver->getType());
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
+        self::assertFalse($this->resolver->supports(ProductVariantInterface::class));
+        self::assertFalse($this->resolver->supports(\stdClass::class));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_the_cheapest_enabled_variant_price(): void
+    {
+        $channel = $this->prophesize(ChannelInterface::class)->reveal();
+        $product = $this->product([
+            $this->variant($channel, 1500),
+            $this->variant($channel, 999),
+            $this->variant($channel, 1299),
+        ]);
+
+        self::assertSame(999, $this->resolver->resolve($product, new FeedContext($channel)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_disabled_variants(): void
+    {
+        $channel = $this->prophesize(ChannelInterface::class)->reveal();
+        $product = $this->product([
+            $this->variant($channel, 1500),
+            $this->variant($channel, 500, enabled: false),
+        ]);
+
+        self::assertSame(1500, $this->resolver->resolve($product, new FeedContext($channel)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_when_no_enabled_variant_has_a_price(): void
+    {
+        $channel = $this->prophesize(ChannelInterface::class)->reveal();
+        $product = $this->product([
+            $this->variant($channel, null),
+            $this->variant($channel, 700, enabled: false),
+        ]);
+
+        self::assertNull($this->resolver->resolve($product, new FeedContext($channel)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_when_the_context_has_no_channel(): void
+    {
+        self::assertNull($this->resolver->resolve($this->product([]), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_an_unsupported_entity(): void
+    {
+        $channel = $this->prophesize(ChannelInterface::class)->reveal();
+
+        self::assertNull($this->resolver->resolve(new \stdClass(), new FeedContext($channel)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_the_price_to_the_context_currency(): void
+    {
+        $baseCurrency = $this->prophesize(CurrencyInterface::class);
+        $baseCurrency->getCode()->willReturn('USD');
+
+        $channel = $this->prophesize(ChannelInterface::class);
+        $channel->getBaseCurrency()->willReturn($baseCurrency->reveal());
+        $channel = $channel->reveal();
+
+        $product = $this->product([$this->variant($channel, 999)]);
+
+        $sylius = $this->prophesize(CurrencyConverterInterface::class);
+        $sylius->convert(999, 'USD', 'EUR')->willReturn(850);
+
+        $resolver = new FromPriceResolver(new ContextCurrencyConverter($sylius->reveal()));
+
+        self::assertSame(850, $resolver->resolve($product, new FeedContext($channel, null, 'EUR')));
+    }
+}

--- a/tests/Unit/ValueResolver/Product/IdResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/IdResolverTest.php
@@ -9,6 +9,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\ValueResolver\Product\IdResolver;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 final class IdResolverTest extends TestCase
@@ -31,6 +32,7 @@ final class IdResolverTest extends TestCase
         self::assertSame('setono_sylius_feed.value_resolver.id', $this->resolver->getLabel());
         self::assertSame(FieldType::STRING, $this->resolver->getType());
         self::assertTrue($this->resolver->supports(ProductVariantInterface::class));
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
         self::assertFalse($this->resolver->supports(\stdClass::class));
     }
 
@@ -43,6 +45,17 @@ final class IdResolverTest extends TestCase
         $variant->getCode()->willReturn('VARIANT-1');
 
         self::assertSame('VARIANT-1', $this->resolver->resolve($variant->reveal(), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_the_product_code(): void
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getCode()->willReturn('PROD-1');
+
+        self::assertSame('PROD-1', $this->resolver->resolve($product->reveal(), new FeedContext()));
     }
 
     /**

--- a/tests/Unit/ValueResolver/Product/IsConfigurableResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/IsConfigurableResolverTest.php
@@ -24,13 +24,18 @@ final class IsConfigurableResolverTest extends TestCase
         $this->resolver = new IsConfigurableResolver();
     }
 
+    private function productWithVariantCount(int $count): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getVariants()->willReturn(new ArrayCollection(array_fill(0, $count, $this->prophesize(ProductVariantInterface::class)->reveal())));
+
+        return $product->reveal();
+    }
+
     private function variantWithVariantCount(int $count): ProductVariantInterface
     {
         $variant = $this->prophesize(ProductVariantInterface::class);
-
-        $product = $this->prophesize(ProductInterface::class);
-        $product->getVariants()->willReturn(new ArrayCollection(array_fill(0, $count, $variant->reveal())));
-        $variant->getProduct()->willReturn($product->reveal());
+        $variant->getProduct()->willReturn($this->productWithVariantCount($count));
 
         return $variant->reveal();
     }
@@ -44,13 +49,14 @@ final class IsConfigurableResolverTest extends TestCase
         self::assertSame('setono_sylius_feed.value_resolver.is_configurable', $this->resolver->getLabel());
         self::assertSame(FieldType::BOOL, $this->resolver->getType());
         self::assertTrue($this->resolver->supports(ProductVariantInterface::class));
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
         self::assertFalse($this->resolver->supports(\stdClass::class));
     }
 
     /**
      * @test
      */
-    public function it_is_true_for_a_multi_variant_product(): void
+    public function it_is_true_for_a_multi_variant_product_via_a_variant(): void
     {
         self::assertTrue($this->resolver->resolve($this->variantWithVariantCount(2), new FeedContext()));
     }
@@ -58,9 +64,25 @@ final class IsConfigurableResolverTest extends TestCase
     /**
      * @test
      */
-    public function it_is_false_for_a_single_variant_product(): void
+    public function it_is_false_for_a_single_variant_product_via_a_variant(): void
     {
         self::assertFalse($this->resolver->resolve($this->variantWithVariantCount(1), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_true_for_a_multi_variant_product_entity(): void
+    {
+        self::assertTrue($this->resolver->resolve($this->productWithVariantCount(2), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_false_for_a_single_variant_product_entity(): void
+    {
+        self::assertFalse($this->resolver->resolve($this->productWithVariantCount(1), new FeedContext()));
     }
 
     /**

--- a/tests/Unit/ValueResolver/Product/ProductAvailabilityResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/ProductAvailabilityResolverTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\ValueResolver\Product;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Item\Google\Availability;
+use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\ValueResolver\Product\ProductAvailabilityResolver;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+final class ProductAvailabilityResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ProductAvailabilityResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ProductAvailabilityResolver();
+    }
+
+    private function trackedVariant(int $onHand, int $onHold = 0): ProductVariantInterface
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHand()->willReturn($onHand);
+        $variant->getOnHold()->willReturn($onHold);
+
+        return $variant->reveal();
+    }
+
+    private function untrackedVariant(): ProductVariantInterface
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->isTracked()->willReturn(false);
+
+        return $variant->reveal();
+    }
+
+    /**
+     * @param list<ProductVariantInterface> $variants
+     */
+    private function product(array $variants): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getVariants()->willReturn(new ArrayCollection($variants));
+
+        return $product->reveal();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('product_availability', $this->resolver->getName());
+        self::assertSame('setono_sylius_feed.value_resolver.product_availability', $this->resolver->getLabel());
+        self::assertSame(FieldType::STRING, $this->resolver->getType());
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
+        self::assertFalse($this->resolver->supports(ProductVariantInterface::class));
+        self::assertFalse($this->resolver->supports(\stdClass::class));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_in_stock_when_an_untracked_variant_exists(): void
+    {
+        $product = $this->product([$this->trackedVariant(0), $this->untrackedVariant()]);
+
+        self::assertSame(Availability::IN_STOCK->value, $this->resolver->resolve($product, new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_in_stock_when_a_tracked_variant_has_available_stock(): void
+    {
+        $product = $this->product([$this->trackedVariant(0), $this->trackedVariant(5, 2)]);
+
+        self::assertSame(Availability::IN_STOCK->value, $this->resolver->resolve($product, new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_out_of_stock_when_no_variant_has_available_stock(): void
+    {
+        $product = $this->product([$this->trackedVariant(0), $this->trackedVariant(3, 3)]);
+
+        self::assertSame(Availability::OUT_OF_STOCK->value, $this->resolver->resolve($product, new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_out_of_stock_for_a_product_without_variants(): void
+    {
+        self::assertSame(Availability::OUT_OF_STOCK->value, $this->resolver->resolve($this->product([]), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_an_unsupported_entity(): void
+    {
+        self::assertNull($this->resolver->resolve(new \stdClass(), new FeedContext()));
+    }
+}

--- a/tests/Unit/ValueResolver/Product/TitleResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/TitleResolverTest.php
@@ -33,13 +33,14 @@ final class TitleResolverTest extends TestCase
         self::assertSame('setono_sylius_feed.value_resolver.title', $this->resolver->getLabel());
         self::assertSame(FieldType::STRING, $this->resolver->getType());
         self::assertTrue($this->resolver->supports(ProductVariantInterface::class));
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
         self::assertFalse($this->resolver->supports(\stdClass::class));
     }
 
     /**
      * @test
      */
-    public function it_resolves_the_translated_product_name(): void
+    public function it_resolves_the_translated_product_name_from_a_variant(): void
     {
         $translation = $this->prophesize(ProductTranslationInterface::class);
         $translation->getName()->willReturn('Acme Shoe');
@@ -51,6 +52,20 @@ final class TitleResolverTest extends TestCase
         $variant->getProduct()->willReturn($product->reveal());
 
         self::assertSame('Acme Shoe', $this->resolver->resolve($variant->reveal(), new FeedContext(null, 'en_US')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_the_translated_product_name_from_a_product(): void
+    {
+        $translation = $this->prophesize(ProductTranslationInterface::class);
+        $translation->getName()->willReturn('Acme Shoe');
+
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getTranslation('en_US')->willReturn($translation->reveal());
+
+        self::assertSame('Acme Shoe', $this->resolver->resolve($product->reveal(), new FeedContext(null, 'en_US')));
     }
 
     /**

--- a/tests/Unit/ValueResolver/Product/VariantCountResolverTest.php
+++ b/tests/Unit/ValueResolver/Product/VariantCountResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\ValueResolver\Product;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\ValueResolver\Product\VariantCountResolver;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+final class VariantCountResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private VariantCountResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new VariantCountResolver();
+    }
+
+    private function productWithVariantCount(int $count): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->getVariants()->willReturn(new ArrayCollection(array_fill(0, $count, $this->prophesize(ProductVariantInterface::class)->reveal())));
+
+        return $product->reveal();
+    }
+
+    /**
+     * @test
+     */
+    public function it_describes_itself(): void
+    {
+        self::assertSame('variant_count', $this->resolver->getName());
+        self::assertSame('setono_sylius_feed.value_resolver.variant_count', $this->resolver->getLabel());
+        self::assertSame(FieldType::INTEGER, $this->resolver->getType());
+        self::assertTrue($this->resolver->supports(ProductVariantInterface::class));
+        self::assertTrue($this->resolver->supports(ProductInterface::class));
+        self::assertFalse($this->resolver->supports(\stdClass::class));
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_the_variants_of_a_product_entity(): void
+    {
+        self::assertSame(3, $this->resolver->resolve($this->productWithVariantCount(3), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_the_variants_of_a_products_parent_via_a_variant_entity(): void
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->getProduct()->willReturn($this->productWithVariantCount(2));
+
+        self::assertSame(2, $this->resolver->resolve($variant->reveal(), new FeedContext()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_an_unsupported_entity(): void
+    {
+        self::assertNull($this->resolver->resolve(new \stdClass(), new FeedContext()));
+    }
+}

--- a/tests/Unit/Writer/CsvWriterTest.php
+++ b/tests/Unit/Writer/CsvWriterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Writer;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Writer\CsvWriter;
+use Setono\SyliusFeedPlugin\Writer\CsvWriterConfig;
+
+final class CsvWriterTest extends TestCase
+{
+    /**
+     * @return resource
+     */
+    private function stream()
+    {
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+
+        return $stream;
+    }
+
+    private function item(string $id): FeedItem
+    {
+        $item = new FeedItem(new \stdClass(), new FeedContext());
+        $item->set('id', $id);
+
+        return $item;
+    }
+
+    /**
+     * @test
+     */
+    public function it_writes_a_header_row_and_one_row_per_item_keyed_by_the_header(): void
+    {
+        $stream = $this->stream();
+        $writer = new CsvWriter();
+        $writer->open($stream, new FeedContext(), (new CsvWriterConfig())->withHeader(['id', 'title', 'images']));
+        $writer->writePreamble();
+
+        $first = $this->item('SKU-1');
+        $first->set('title', 'Acme, Shoe');
+        $first->set('images', ['a.jpg', 'b.jpg']);
+        $writer->writeItem($first);
+
+        // second item is missing 'title' entirely → empty cell; order still follows the header
+        $second = $this->item('SKU-2');
+        $second->set('images', 'single.jpg');
+        $writer->writeItem($second);
+
+        $writer->writeEpilogue();
+        $writer->close();
+
+        rewind($stream);
+        $csv = stream_get_contents($stream);
+        fclose($stream);
+        self::assertIsString($csv);
+
+        $lines = array_values(array_filter(explode("\n", trim($csv)), static fn (string $line): bool => '' !== $line));
+        self::assertSame('id,title,images', $lines[0]);
+        // comma inside a value → league/csv quotes it; a list is joined with a comma and then quoted
+        self::assertSame('SKU-1,"Acme, Shoe","a.jpg,b.jpg"', $lines[1]);
+        // missing 'title' becomes an empty cell in the right column
+        self::assertSame('SKU-2,,single.jpg', $lines[2]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prepends_a_utf8_bom_when_configured(): void
+    {
+        $stream = $this->stream();
+        $writer = new CsvWriter();
+        $writer->open($stream, new FeedContext(), new CsvWriterConfig(';', '"', ['id'], true));
+        $writer->writePreamble();
+        $writer->close();
+
+        rewind($stream);
+        $csv = stream_get_contents($stream);
+        fclose($stream);
+        self::assertIsString($csv);
+
+        self::assertStringStartsWith("\xEF\xBB\xBF", $csv);
+    }
+
+    /**
+     * @test
+     */
+    public function it_honours_a_custom_delimiter(): void
+    {
+        $stream = $this->stream();
+        $writer = new CsvWriter();
+        $writer->open($stream, new FeedContext(), (new CsvWriterConfig(';'))->withHeader(['a', 'b']));
+        $writer->writePreamble();
+
+        $item = $this->item('x');
+        $item->set('a', '1');
+        $item->set('b', '2');
+        $writer->writeItem($item);
+        $writer->close();
+
+        rewind($stream);
+        $csv = stream_get_contents($stream);
+        fclose($stream);
+        self::assertIsString($csv);
+
+        self::assertStringContainsString('a;b', $csv);
+        self::assertStringContainsString('1;2', $csv);
+    }
+}


### PR DESCRIPTION
## M5 — Channel breadth + CSV + multi-source + external enrichment

Broadens the engine to more destinations and adds the LookupTable enrichment resource. Four
chunks (7 commits); **503 tests**; the admin LookupTable flow is **browser-verified**.

### CSV writer + format presets
- **`CsvWriter`** (`league/csv`, the `csv` writer family): a header row that is the **union of the
  feed's output fields** (computed by the generator, injected into the config) then one row per
  item keyed by header — so heterogeneous multi-source rows line up; missing → empty cell, list →
  joined, optional UTF-8 BOM. `csv` format preset.
- **`generic_xml`** + **`partner_ads`** XmlWriter format presets — new destinations are format
  presets, **no new writer class**.

### Channel mapping presets
`Meta` (csv, space-separated availability via `value_map`), `Bing` + `Pinterest` (google_rss),
`TikTok` (csv, `sku_id`/`product_page_url`), `Partner-ads` (partner_ads, Danish element names). They
show up in the admin target picker. **Acceptance:** a valid Meta CSV and a valid Partner-ads XML are
produced from the same catalog purely by choosing the preset — no code changes.

### `product` FeedType + multi-source
- Shared resolvers (`id`, `title`, `description`, `link`, `main_image`, `additional_images`,
  `is_configurable`) now support **both** `ProductVariant` and `Product` (`ProductAwareTrait`);
  variant behaviour is unchanged. New product-level resolvers: `variant_count`, `from_price`,
  `product_availability`.
- `ProductDataSource` + `ProductFeedType`. **Multi-source proven end to end:** one CSV feed with a
  `product` source and a `product_variant` source emits both product-level and variant-level rows
  under a union header.

### External enrichment — the LookupTable resource (§10.1)
- **`LookupTable`** Sylius resource (entity/mapping/repository/admin grid + CRUD + **Refresh**
  action + menu). The `rows` property maps to a `lookup_rows` json column (`rows` is a MySQL
  reserved word).
- Pluggable **`LookupSourceInterface`** with built-in **`csv`** (uploaded file) and **`url`**
  (downloads CSV/TSV — covers a published Google Sheet `…/export?format=csv`).
- **`LookupTableRefresher`** imports rows keyed by `keyColumn`, stamping `refreshedAt`; on **any**
  failure it **keeps the last-good rows** and logs a warning — a broken source never blanks the
  serving data.
- **`DatabaseLookup`** (the production `LookupInterface`) resolves `lookup(table, key, column)` in
  expressions/twig against the tables (loaded once + cached per run).
- **`lookup:{code}:{column}`** source references resolve in the generator via the table's
  `joinField` — so `concat(["value", "lookup:badges:badge"])` (the exact §10.1 case) and GTIN
  backfill (`g:gtin ← lookup:…`) work end to end.
- **Browser-verified:** create a lookup table → Refresh fetches a CSV URL and imports the keyed
  rows (`refreshedAt` stamped) → the flash shows.

### CI note
Verified locally against the **updated** PHPStan/Rector/ECS (CI runs `composer update`), so the
substantive gate (Unit / Integration / Static Code Analysis / Coding Standards) should be green.
The **Backwards Compatibility Check** carries intentional breaks (the `FieldMappingEvaluator`
constructor gained a lookup dependency; `Configuration` gained the resource) — left visible per the
rewrite policy — and **Dependency Analysis** + **Mutation** remain the standing rewrite reds.
