### PR TITLE
M6 — Filtering, validation, reporting, preview & publish gate

### DIFF
--- a/src/Audit/AuditReport.php
+++ b/src/Audit/AuditReport.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Audit;
+
+/**
+ * A purely advisory quality report over the items a preview would include (§11): it excludes
+ * nothing, it only surfaces per-field fill rates, non-blocking soft warnings, and value
+ * distributions so an admin can spot data-quality issues before shipping the feed.
+ */
+final class AuditReport
+{
+    /**
+     * @param array<string, float> $fillRates output field => fraction (0..1) of included items where the field is non-empty
+     * @param list<array{type: string, field: string, count: int}> $warnings advisory soft warnings, each with the number of affected items
+     * @param array<string, array<string, int>> $distributions output field => value => count
+     */
+    public function __construct(
+        public readonly array $fillRates,
+        public readonly array $warnings,
+        public readonly array $distributions,
+    ) {
+    }
+}

--- a/src/Audit/FeedAuditService.php
+++ b/src/Audit/FeedAuditService.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Audit;
+
+use Setono\SyliusFeedPlugin\Preview\PreviewResult;
+
+/**
+ * @see FeedAuditServiceInterface
+ */
+final class FeedAuditService implements FeedAuditServiceInterface
+{
+    /**
+     * Google Shopping caps the title at 150 characters; longer titles are truncated by the channel.
+     */
+    private const MAX_TITLE_LENGTH = 150;
+
+    /** @var list<string> */
+    private const TITLE_FIELDS = ['g:title', 'title'];
+
+    /** @var list<string> */
+    private const DESCRIPTION_FIELDS = ['g:description', 'description'];
+
+    /** @var list<string> */
+    private const PRICE_FIELDS = ['g:price', 'price'];
+
+    /** @var list<string> */
+    private const AVAILABILITY_FIELDS = ['g:availability', 'availability'];
+
+    public function audit(PreviewResult $result): AuditReport
+    {
+        $bags = $result->included;
+
+        return new AuditReport(
+            $this->fillRates($bags),
+            $this->warnings($bags),
+            $this->distributions($bags),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $bags
+     *
+     * @return array<string, float>
+     */
+    private function fillRates(array $bags): array
+    {
+        $total = count($bags);
+        if (0 === $total) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ($bags as $bag) {
+            foreach (array_keys($bag) as $field) {
+                if (!in_array($field, $fields, true)) {
+                    $fields[] = $field;
+                }
+            }
+        }
+
+        $fillRates = [];
+        foreach ($fields as $field) {
+            $filled = 0;
+            foreach ($bags as $bag) {
+                if (array_key_exists($field, $bag) && !$this->isEmpty($bag[$field])) {
+                    ++$filled;
+                }
+            }
+
+            $fillRates[$field] = (float) $filled / $total;
+        }
+
+        return $fillRates;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $bags
+     *
+     * @return list<array{type: string, field: string, count: int}>
+     */
+    private function warnings(array $bags): array
+    {
+        $warnings = [];
+
+        $titleField = $this->firstPresentField($bags, self::TITLE_FIELDS);
+        if (null !== $titleField) {
+            $count = $this->countMatching($bags, $titleField, static fn (mixed $value): bool => is_string($value) && mb_strlen($value) > self::MAX_TITLE_LENGTH);
+            if ($count > 0) {
+                $warnings[] = ['type' => 'title_too_long', 'field' => $titleField, 'count' => $count];
+            }
+        }
+
+        $descriptionField = $this->firstPresentField($bags, self::DESCRIPTION_FIELDS);
+        if (null !== $descriptionField) {
+            $count = $this->countMatching($bags, $descriptionField, static fn (mixed $value): bool => is_string($value) && 1 === preg_match('/<[^>]+>/', $value));
+            if ($count > 0) {
+                $warnings[] = ['type' => 'description_contains_html', 'field' => $descriptionField, 'count' => $count];
+            }
+        }
+
+        $priceField = $this->firstPresentField($bags, self::PRICE_FIELDS);
+        if (null !== $priceField) {
+            $count = $this->countMatching($bags, $priceField, fn (mixed $value): bool => $this->isPriceEmpty($value));
+            if ($count > 0) {
+                $warnings[] = ['type' => 'price_empty', 'field' => $priceField, 'count' => $count];
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $bags
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function distributions(array $bags): array
+    {
+        $distributions = [];
+
+        $availabilityField = $this->firstPresentField($bags, self::AVAILABILITY_FIELDS);
+        if (null !== $availabilityField) {
+            $counts = [];
+            foreach ($bags as $bag) {
+                $value = $bag[$availabilityField] ?? null;
+                if (is_scalar($value)) {
+                    $key = (string) $value;
+                    $counts[$key] = ($counts[$key] ?? 0) + 1;
+                }
+            }
+
+            if ([] !== $counts) {
+                $distributions[$availabilityField] = $counts;
+            }
+        }
+
+        $priceField = $this->firstPresentField($bags, self::PRICE_FIELDS);
+        if (null !== $priceField) {
+            $zero = 0;
+            $nonZero = 0;
+            foreach ($bags as $bag) {
+                if (!array_key_exists($priceField, $bag)) {
+                    continue;
+                }
+
+                if ($this->isPriceEmpty($bag[$priceField])) {
+                    ++$zero;
+                } else {
+                    ++$nonZero;
+                }
+            }
+
+            if ($zero + $nonZero > 0) {
+                $distributions[$priceField] = ['zero' => $zero, 'non_zero' => $nonZero];
+            }
+        }
+
+        return $distributions;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $bags
+     * @param callable(mixed): bool $matches
+     */
+    private function countMatching(array $bags, string $field, callable $matches): int
+    {
+        $count = 0;
+        foreach ($bags as $bag) {
+            if ($matches($bag[$field] ?? null)) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * The first of the candidate keys that appears in any bag — resolves the logical concept (title,
+     * price, …) to the concrete output field the feed actually uses (`g:title` vs `title`, …).
+     *
+     * @param list<array<string, mixed>> $bags
+     * @param list<string> $candidates
+     */
+    private function firstPresentField(array $bags, array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            foreach ($bags as $bag) {
+                if (array_key_exists($candidate, $bag)) {
+                    return $candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isEmpty(mixed $value): bool
+    {
+        return null === $value || '' === $value || [] === $value;
+    }
+
+    /**
+     * Advisory: a price is "empty" when it is missing, empty, or resolves to a zero amount — a
+     * leading numeric of 0 in a formatted string like "0.00 USD" counts as zero.
+     */
+    private function isPriceEmpty(mixed $value): bool
+    {
+        if ($this->isEmpty($value)) {
+            return true;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return 0.0 === (float) $value;
+        }
+
+        if (is_string($value)) {
+            if (1 === preg_match('/-?\d+(?:[.,]\d+)?/', $value, $matches)) {
+                return 0.0 === (float) str_replace(',', '.', $matches[0]);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Audit/FeedAuditServiceInterface.php
+++ b/src/Audit/FeedAuditServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Audit;
+
+use Setono\SyliusFeedPlugin\Preview\PreviewResult;
+
+/**
+ * Computes an advisory {@see AuditReport} over a {@see PreviewResult}'s included items (§11). It
+ * never re-runs the pipeline — it reads the already-mapped output bags the preview produced.
+ */
+interface FeedAuditServiceInterface
+{
+    public function audit(PreviewResult $result): AuditReport;
+}

--- a/src/Command/ProcessFeedCommand.php
+++ b/src/Command/ProcessFeedCommand.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\Command;
 
+use Setono\SyliusFeedPlugin\Audit\AuditReport;
+use Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface;
+use Setono\SyliusFeedPlugin\Context\ContextFactoryInterface;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Message\Command\ProcessFeed;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -18,16 +23,29 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsCommand(name: 'setono:feed:process', description: 'Dispatch feed generation (all enabled feeds, or one with --feed=CODE)')]
 final class ProcessFeedCommand extends Command
 {
+    private const DEFAULT_PREVIEW_LIMIT = 50;
+
+    private const SAMPLE_ROWS = 5;
+
+    private const SAMPLE_FIELDS = 6;
+
     public function __construct(
         private readonly RepositoryInterface $feedRepository,
         private readonly MessageBusInterface $commandBus,
+        private readonly ContextFactoryInterface $contextFactory,
+        private readonly PreviewServiceInterface $previewService,
+        private readonly FeedAuditServiceInterface $auditService,
     ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->addOption('feed', null, InputOption::VALUE_REQUIRED, 'Process only the feed with this code');
+        $this
+            ->addOption('feed', null, InputOption::VALUE_REQUIRED, 'Process only the feed with this code')
+            ->addOption('preview', null, InputOption::VALUE_OPTIONAL, 'Dry-run: print the funnel + a few sample rows instead of generating (optionally set the sample size, default ' . self::DEFAULT_PREVIEW_LIMIT . ')', false)
+            ->addOption('audit', null, InputOption::VALUE_NONE, 'Dry-run: also print fill rates and soft warnings (implies --preview)')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -47,6 +65,21 @@ final class ProcessFeedCommand extends Command
             return Command::SUCCESS;
         }
 
+        $audit = true === $input->getOption('audit');
+        $previewOption = $input->getOption('preview');
+
+        if ($audit || false !== $previewOption) {
+            $limit = is_numeric($previewOption) ? max(1, (int) $previewOption) : self::DEFAULT_PREVIEW_LIMIT;
+
+            foreach ($feeds as $feed) {
+                if ($feed instanceof FeedInterface) {
+                    $this->previewFeed($io, $feed, $limit, $audit);
+                }
+            }
+
+            return Command::SUCCESS;
+        }
+
         foreach ($feeds as $feed) {
             if (!$feed instanceof FeedInterface) {
                 continue;
@@ -58,5 +91,98 @@ final class ProcessFeedCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function previewFeed(SymfonyStyle $io, FeedInterface $feed, int $limit, bool $audit): void
+    {
+        $contexts = $this->contextFactory->create($feed);
+        $context = $contexts[0] ?? new FeedContext();
+
+        $result = $this->previewService->preview($feed, $context, $limit);
+        $funnel = $result->funnel;
+
+        $io->section(sprintf('%s (%s)', (string) $feed->getCode(), $context->key()));
+        $io->table(
+            ['Stage', 'Count'],
+            [
+                ['Sampled', (string) $funnel->source],
+                ['After pre-filters', (string) $funnel->afterPreFilters],
+                ['After mapping & validation', (string) $funnel->afterMappingValidation],
+                ['After post-filters', (string) $funnel->afterPostFilters],
+                ['Included', (string) $funnel->included],
+            ],
+        );
+
+        $includedSample = array_slice($result->included, 0, self::SAMPLE_ROWS);
+        if ([] !== $includedSample) {
+            $io->writeln('<info>Included sample:</info>');
+            foreach ($includedSample as $bag) {
+                $io->writeln(' - ' . $this->summarizeBag($bag));
+            }
+            $io->newLine();
+        }
+
+        $excludedSample = array_slice($result->excluded, 0, self::SAMPLE_ROWS);
+        if ([] !== $excludedSample) {
+            $io->writeln('<comment>Excluded sample:</comment>');
+            foreach ($excludedSample as $row) {
+                $io->writeln(sprintf(' - %s: %s', $row['item'] ?? '(no id)', $row['reason']));
+            }
+            $io->newLine();
+        }
+
+        if ($audit) {
+            $this->printAudit($io, $this->auditService->audit($result));
+        }
+    }
+
+    private function printAudit(SymfonyStyle $io, AuditReport $report): void
+    {
+        if ([] !== $report->fillRates) {
+            $rows = [];
+            foreach ($report->fillRates as $field => $rate) {
+                $rows[] = [$field, sprintf('%.1f%%', $rate * 100)];
+            }
+            $io->writeln('<info>Fill rates:</info>');
+            $io->table(['Field', 'Fill rate'], $rows);
+        }
+
+        if ([] !== $report->warnings) {
+            $rows = [];
+            foreach ($report->warnings as $warning) {
+                $rows[] = [$warning['type'], $warning['field'], (string) $warning['count']];
+            }
+            $io->writeln('<comment>Soft warnings:</comment>');
+            $io->table(['Type', 'Field', 'Count'], $rows);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $bag
+     */
+    private function summarizeBag(array $bag): string
+    {
+        $parts = [];
+        foreach ($bag as $key => $value) {
+            $parts[] = sprintf('%s=%s', $key, $this->stringifyValue($value));
+        }
+
+        return implode(', ', array_slice($parts, 0, self::SAMPLE_FIELDS));
+    }
+
+    private function stringifyValue(mixed $value): string
+    {
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_array($value)) {
+            return implode('|', array_map(
+                static fn (mixed $item): string => is_scalar($item) ? (string) $item : get_debug_type($item),
+                $value,
+            ));
+        }
+
+        return get_debug_type($value);
     }
 }

--- a/src/Controller/Admin/PreviewFeedAction.php
+++ b/src/Controller/Admin/PreviewFeedAction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Controller\Admin;
+
+use Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface;
+use Setono\SyliusFeedPlugin\Context\ContextFactoryInterface;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedRepositoryInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+
+/**
+ * Admin dry-run preview (§11): runs the generator pipeline over a bounded sample of the feed's
+ * first context WITHOUT writing anything, then renders the include/exclude funnel, a sample of the
+ * mapped output, the excluded items with their drop reasons, and the advisory audit.
+ */
+final class PreviewFeedAction
+{
+    public function __construct(
+        private readonly FeedRepositoryInterface $feedRepository,
+        private readonly ContextFactoryInterface $contextFactory,
+        private readonly PreviewServiceInterface $previewService,
+        private readonly FeedAuditServiceInterface $auditService,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function __invoke(int|string $id): Response
+    {
+        $feed = $this->feedRepository->find($id);
+        if (!$feed instanceof FeedInterface) {
+            throw new NotFoundHttpException(sprintf('There is no feed with id "%s"', $id));
+        }
+
+        $contexts = $this->contextFactory->create($feed);
+        $context = $contexts[0] ?? new FeedContext();
+
+        $preview = $this->previewService->preview($feed, $context);
+        $audit = $this->auditService->audit($preview);
+
+        $columns = [];
+        foreach ($preview->included as $bag) {
+            foreach (array_keys($bag) as $key) {
+                if (!in_array($key, $columns, true)) {
+                    $columns[] = $key;
+                }
+            }
+        }
+
+        return new Response($this->twig->render('@SetonoSyliusFeedPlugin/admin/feed/preview.html.twig', [
+            'feed' => $feed,
+            'context' => $context,
+            'preview' => $preview,
+            'audit' => $audit,
+            'columns' => $columns,
+        ]));
+    }
+}

--- a/src/Controller/Admin/PublishContextAnywayAction.php
+++ b/src/Controller/Admin/PublishContextAnywayAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Controller\Admin;
+
+use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\FilesystemOperator;
+use Setono\Doctrine\ORMTrait;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Admin "Publish anyway" action (§6.6): overrides the publish gate for one blocked context by
+ * promoting its retained staging candidate to canonical storage and marking the latest result as
+ * published. Redirects back to the feed's results view with a flash.
+ */
+final class PublishContextAnywayAction
+{
+    use ORMTrait;
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly FeedRepositoryInterface $feedRepository,
+        private readonly FeedContextResultRepositoryInterface $feedContextResultRepository,
+        private readonly FilesystemOperator $feedTmpFilesystem,
+        private readonly FilesystemOperator $feedFilesystem,
+        private readonly RouterInterface $router,
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public function __invoke(Request $request, int|string $id, string $contextKey): Response
+    {
+        $feed = $this->feedRepository->find($id);
+        if (!$feed instanceof FeedInterface) {
+            throw new NotFoundHttpException(sprintf('There is no feed with id "%s"', $id));
+        }
+
+        $directory = (string) $feed->getCode();
+
+        foreach ($this->feedTmpFilesystem->listContents($directory, true) as $item) {
+            if (!$item->isFile()) {
+                continue;
+            }
+
+            $path = $item->path();
+            if (pathinfo($path, \PATHINFO_FILENAME) !== $contextKey) {
+                continue;
+            }
+
+            $this->feedFilesystem->writeStream($path, $this->feedTmpFilesystem->readStream($path));
+            $this->feedTmpFilesystem->delete($path);
+        }
+
+        $result = $this->feedContextResultRepository->findLatestForContext($feed, $contextKey);
+        if (null !== $result) {
+            $result->setPublishState(FeedContextResultInterface::PUBLISH_STATE_PUBLISHED);
+            $this->getManager($result)->flush();
+        }
+
+        $session = $request->getSession();
+        if ($session instanceof Session) {
+            $session->getFlashBag()->add('success', 'setono_sylius_feed.feed.context_published');
+        }
+
+        return new RedirectResponse(
+            $this->router->generate('setono_sylius_feed_admin_feed_results', ['id' => $feed->getId()]),
+        );
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,10 +7,13 @@ namespace Setono\SyliusFeedPlugin\DependencyInjection;
 use Setono\SyliusFeedPlugin\Form\Type\FeedType;
 use Setono\SyliusFeedPlugin\Form\Type\LookupTableType;
 use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSource;
 use Setono\SyliusFeedPlugin\Model\FeedTranslation;
 use Setono\SyliusFeedPlugin\Model\LookupTable;
 use Setono\SyliusFeedPlugin\Model\LookupTableInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepository;
 use Setono\SyliusFeedPlugin\Repository\FeedRepository;
 use Setono\SyliusFeedPlugin\Repository\LookupTableRepository;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
@@ -127,6 +130,23 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('repository')->defaultValue(LookupTableRepository::class)->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                         ->scalarNode('form')->defaultValue(LookupTableType::class)->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('feed_context_result')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(FeedContextResult::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(FeedContextResultInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->defaultValue(FeedContextResultRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                        ->scalarNode('form')->defaultValue(DefaultResourceType::class)->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/DependencyInjection/SetonoSyliusFeedExtension.php
+++ b/src/DependencyInjection/SetonoSyliusFeedExtension.php
@@ -10,6 +10,7 @@ use Setono\SyliusFeedPlugin\Lookup\LookupSourceInterface;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Operator\OperatorInterface;
+use Setono\SyliusFeedPlugin\Publish\GuardrailInterface;
 use Setono\SyliusFeedPlugin\Transformation\TransformationInterface;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
 use Setono\SyliusFeedPlugin\Workflow\FeedGraph;
@@ -37,6 +38,7 @@ final class SetonoSyliusFeedExtension extends AbstractResourceExtension implemen
         OperatorInterface::class => 'setono_sylius_feed.operator',
         FeedWriterInterface::class => 'setono_sylius_feed.writer',
         FormatInterface::class => 'setono_sylius_feed.format',
+        GuardrailInterface::class => 'setono_sylius_feed.guardrail',
     ];
 
     public function load(array $configs, ContainerBuilder $container): void

--- a/src/Event/FeedPublishBlockedEvent.php
+++ b/src/Event/FeedPublishBlockedEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Event;
+
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+
+/**
+ * Dispatched when the publish gate trips for a context (§6.6): either promotion was blocked, or a
+ * non-blocking `warn` guardrail recorded a concern. Listeners can notify operators, log, or open a
+ * task. {@see $blocked} distinguishes a hard block (the live feed was kept) from a warning (the new
+ * candidate was still promoted).
+ */
+final class FeedPublishBlockedEvent
+{
+    /**
+     * @param list<string> $reasons
+     */
+    public function __construct(
+        public readonly FeedInterface $feed,
+        public readonly string $contextKey,
+        public readonly array $reasons,
+        public readonly bool $blocked,
+    ) {
+    }
+}

--- a/src/EventSubscriber/MoveGeneratedFeedSubscriber.php
+++ b/src/EventSubscriber/MoveGeneratedFeedSubscriber.php
@@ -6,20 +6,25 @@ namespace Setono\SyliusFeedPlugin\EventSubscriber;
 
 use League\Flysystem\FilesystemOperator;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
 use Setono\SyliusFeedPlugin\Workflow\FeedGraph;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\CompletedEvent;
 
 /**
- * On `complete`, swaps the feed's freshly generated files from temporary to canonical storage so
- * the public feed is never served half-written (§6.3): the canonical directory is replaced with the
- * temporary one, then the temporary copy is removed and the feed is stamped as generated.
+ * On `complete`, promotes each freshly generated context file from staging to canonical storage —
+ * but only per-context and only when the publish gate let it through (§6.6). A context whose latest
+ * result is `blocked` keeps its previously published canonical file live and its candidate is
+ * retained in staging for inspection (and a possible "publish anyway"); every other context is
+ * copied across (overwriting) and its staging copy removed. The canonical directory is never wiped
+ * wholesale, so a blocked context never loses its live file.
  */
 final class MoveGeneratedFeedSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly FilesystemOperator $feedTmpFilesystem,
         private readonly FilesystemOperator $feedFilesystem,
+        private readonly FeedContextResultRepositoryInterface $feedContextResultRepository,
     ) {
     }
 
@@ -39,17 +44,24 @@ final class MoveGeneratedFeedSubscriber implements EventSubscriberInterface
 
         $directory = (string) $feed->getCode();
 
-        $this->feedFilesystem->deleteDirectory($directory);
-
         foreach ($this->feedTmpFilesystem->listContents($directory, true) as $item) {
             if (!$item->isFile()) {
                 continue;
             }
 
-            $this->feedFilesystem->writeStream($item->path(), $this->feedTmpFilesystem->readStream($item->path()));
-        }
+            $path = $item->path();
+            $contextKey = pathinfo($path, \PATHINFO_FILENAME);
+            $result = $this->feedContextResultRepository->findLatestForContext($feed, $contextKey);
 
-        $this->feedTmpFilesystem->deleteDirectory($directory);
+            if (null !== $result && $result->isBlocked()) {
+                // Keep the live canonical file; retain the blocked candidate in staging for inspection.
+                continue;
+            }
+
+            // Published (or no result / no gate): swap the candidate in and drop the staging copy.
+            $this->feedFilesystem->writeStream($path, $this->feedTmpFilesystem->readStream($path));
+            $this->feedTmpFilesystem->delete($path);
+        }
 
         $feed->setLastGeneratedAt(new \DateTimeImmutable());
     }

--- a/src/FeedType/FeedTypeInterface.php
+++ b/src/FeedType/FeedTypeInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\FeedType;
 
+use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 
@@ -28,6 +30,13 @@ interface FeedTypeInterface
     public function getLabel(): string;
 
     public function getDataSource(): DataSourceInterface;
+
+    /**
+     * Create the per-item object for one entity of this feed type. A feed type MAY return a typed
+     * subclass of {@see FeedItem} (e.g. GoogleShoppingItem) so that named accessors and typed-item
+     * validation constraints apply; the default is a plain {@see FeedItem} over the generic bag (§4.2, §11).
+     */
+    public function createItem(object $entity, FeedContext $context): FeedItem;
 
     /**
      * @return list<ScopeDimension>

--- a/src/FeedType/ProductFeedType.php
+++ b/src/FeedType/ProductFeedType.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\FeedType;
 
+use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverRegistryInterface;
@@ -54,6 +56,11 @@ final class ProductFeedType implements FeedTypeInterface
     public function getDataSource(): DataSourceInterface
     {
         return $this->dataSource;
+    }
+
+    public function createItem(object $entity, FeedContext $context): FeedItem
+    {
+        return new FeedItem($entity, $context);
     }
 
     public function getScopeDimensions(): array

--- a/src/FeedType/ProductVariantFeedType.php
+++ b/src/FeedType/ProductVariantFeedType.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFeedPlugin\FeedType;
 
+use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Item\Google\GoogleShoppingItem;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverRegistryInterface;
@@ -54,6 +57,11 @@ final class ProductVariantFeedType implements FeedTypeInterface
     public function getDataSource(): DataSourceInterface
     {
         return $this->dataSource;
+    }
+
+    public function createItem(object $entity, FeedContext $context): FeedItem
+    {
+        return new GoogleShoppingItem($entity, $context);
     }
 
     public function getScopeDimensions(): array

--- a/src/Filter/FilterEvaluator.php
+++ b/src/Filter/FilterEvaluator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Filter;
+
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Model\FeedFilterInterface;
+use Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface;
+use Setono\SyliusFeedPlugin\Reference\ReferenceResolverInterface;
+
+/**
+ * Include/exclude items by (field, operator, value, action) over the shared operator vocabulary
+ * and the one reference-resolution rule (§10, §11).
+ *
+ * Both operands are references: the `field` resolves against the item, and a string `value` is
+ * resolved the same way (so it can point at another field / an earlier output key / a quoted
+ * literal); a non-string `value` is used verbatim. `exclude` drops the item when the operator
+ * matches; `include` keeps only matching items (so a non-match excludes).
+ *
+ * NOTE: filters are evaluated per item. Pushing `pre` filters down into the data source's query
+ * (so the database never returns rows that would be filtered out) is a future optimization.
+ */
+final class FilterEvaluator implements FilterEvaluatorInterface
+{
+    public function __construct(
+        private readonly ReferenceResolverInterface $referenceResolver,
+        private readonly OperatorRegistryInterface $operatorRegistry,
+    ) {
+    }
+
+    public function excludedBy(FeedItem $item, iterable $filters): ?FeedFilterInterface
+    {
+        foreach ($filters as $filter) {
+            if ($this->excludes($filter, $item)) {
+                return $filter;
+            }
+        }
+
+        return null;
+    }
+
+    private function excludes(FeedFilterInterface $filter, FeedItem $item): bool
+    {
+        $field = $filter->getField();
+        $operator = $filter->getOperator();
+
+        // An incomplete filter (no field/operator) is inert — it never excludes anything.
+        if (null === $field || null === $operator) {
+            return false;
+        }
+
+        $left = $this->referenceResolver->resolve($field, null, $item);
+
+        $rawValue = $filter->getValue();
+        $operand = is_string($rawValue) ? $this->referenceResolver->resolve($rawValue, null, $item) : $rawValue;
+
+        $matched = $this->operatorRegistry->get($operator)->matches($left, ['value' => $operand]);
+
+        return FeedFilterInterface::ACTION_EXCLUDE === $filter->getAction() ? $matched : !$matched;
+    }
+}

--- a/src/Filter/FilterEvaluatorInterface.php
+++ b/src/Filter/FilterEvaluatorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Filter;
+
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Model\FeedFilterInterface;
+
+/**
+ * Evaluates a source's filters against a single item to decide inclusion/exclusion (§11). The
+ * `pre`/`post` partitioning is a scheduling concern owned by the generator ({@see FilterSet}); this
+ * contract just answers "does any of these filters exclude the item?".
+ */
+interface FilterEvaluatorInterface
+{
+    /**
+     * Returns the first filter that EXCLUDES the item, or null when every filter passes.
+     *
+     * @param iterable<FeedFilterInterface> $filters
+     */
+    public function excludedBy(FeedItem $item, iterable $filters): ?FeedFilterInterface;
+}

--- a/src/Form/Type/FeedFilterType.php
+++ b/src/Form/Type/FeedFilterType.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Form\Type;
+
+use Setono\SyliusFeedPlugin\Model\FeedFilter;
+use Setono\SyliusFeedPlugin\Model\FeedFilterInterface;
+use Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * One include/exclude filter row (§11): the `field` to test, the `operator` from the shared
+ * vocabulary, the comparison `value` (a reference or quoted literal), the `action`
+ * (include/exclude) and the `stage` (pre/post) at which it runs.
+ */
+final class FeedFilterType extends AbstractType
+{
+    public function __construct(private readonly OperatorRegistryInterface $operatorRegistry)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('field', TextType::class, [
+                'label' => 'setono_sylius_feed.form.feed_filter.field',
+            ])
+            ->add('operator', ChoiceType::class, [
+                'label' => 'setono_sylius_feed.form.feed_filter.operator',
+                'choices' => $this->operatorChoices(),
+                'choice_translation_domain' => false,
+            ])
+            ->add('value', TextType::class, [
+                'required' => false,
+                'label' => 'setono_sylius_feed.form.feed_filter.value',
+                'help' => 'setono_sylius_feed.form.feed_filter.value_help',
+            ])
+            ->add('action', ChoiceType::class, [
+                'label' => 'setono_sylius_feed.form.feed_filter.action',
+                'choices' => [
+                    'setono_sylius_feed.form.feed_filter.action_choices.include' => FeedFilterInterface::ACTION_INCLUDE,
+                    'setono_sylius_feed.form.feed_filter.action_choices.exclude' => FeedFilterInterface::ACTION_EXCLUDE,
+                ],
+            ])
+            ->add('stage', ChoiceType::class, [
+                'label' => 'setono_sylius_feed.form.feed_filter.stage',
+                'choices' => [
+                    'setono_sylius_feed.form.feed_filter.stage_choices.pre' => FeedFilterInterface::STAGE_PRE,
+                    'setono_sylius_feed.form.feed_filter.stage_choices.post' => FeedFilterInterface::STAGE_POST,
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('data_class', FeedFilter::class);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'setono_sylius_feed_feed_filter';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function operatorChoices(): array
+    {
+        $choices = [];
+        foreach ($this->operatorRegistry->all() as $operator) {
+            $name = $operator->getName();
+            $choices[$name] = $name;
+        }
+
+        ksort($choices);
+
+        return $choices;
+    }
+}

--- a/src/Form/Type/FeedSourceType.php
+++ b/src/Form/Type/FeedSourceType.php
@@ -40,6 +40,13 @@ final class FeedSourceType extends AbstractType
                 'allow_delete' => true,
                 'by_reference' => false,
             ])
+            ->add('filters', CollectionType::class, [
+                'label' => 'setono_sylius_feed.form.feed_source.filters',
+                'entry_type' => FeedFilterType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+            ])
         ;
 
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {

--- a/src/Format/CsvFormat.php
+++ b/src/Format/CsvFormat.php
@@ -34,4 +34,9 @@ final class CsvFormat implements FormatInterface
     {
         return [];
     }
+
+    public function getItemValidationGroups(): array
+    {
+        return [];
+    }
 }

--- a/src/Format/FormatInterface.php
+++ b/src/Format/FormatInterface.php
@@ -37,4 +37,15 @@ interface FormatInterface
      * @return list<string>
      */
     public function getRequiredFields(): array;
+
+    /**
+     * The Symfony validation groups to run the typed per-item constraints under for this format
+     * (§11). A format that carries typed-item constraints (e.g. Google Shopping) returns the group(s)
+     * that activate them; a format that only relies on the generic required-field check returns an
+     * empty list, so a typed item (like GoogleShoppingItem) rendered under a non-matching format is
+     * not spuriously rejected.
+     *
+     * @return list<string>
+     */
+    public function getItemValidationGroups(): array;
 }

--- a/src/Format/GenericXmlFormat.php
+++ b/src/Format/GenericXmlFormat.php
@@ -33,4 +33,9 @@ final class GenericXmlFormat implements FormatInterface
     {
         return [];
     }
+
+    public function getItemValidationGroups(): array
+    {
+        return [];
+    }
 }

--- a/src/Format/GoogleRssFormat.php
+++ b/src/Format/GoogleRssFormat.php
@@ -38,4 +38,11 @@ final class GoogleRssFormat implements FormatInterface
     {
         return ['g:id', 'g:title', 'g:description', 'g:link', 'g:image_link', 'g:availability', 'g:price'];
     }
+
+    public function getItemValidationGroups(): array
+    {
+        // Run the GoogleShoppingItem constraint mapping (Default group), which encodes the Google
+        // Merchant product spec on the typed item this format's product_variant source produces.
+        return ['Default'];
+    }
 }

--- a/src/Format/PartnerAdsFormat.php
+++ b/src/Format/PartnerAdsFormat.php
@@ -32,4 +32,9 @@ final class PartnerAdsFormat implements FormatInterface
     {
         return [];
     }
+
+    public function getItemValidationGroups(): array
+    {
+        return [];
+    }
 }

--- a/src/Generator/ExclusionCollector.php
+++ b/src/Generator/ExclusionCollector.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Generator;
+
+/**
+ * Accumulates per-item exclusions during generation (§11): every exclusion is counted, but only the
+ * first {@see self::MAX_RECORDED} reasons are kept, so a feed with many excluded items cannot
+ * exhaust memory. The full count and the bounded sample feed the persisted FeedContextResult.
+ */
+final class ExclusionCollector
+{
+    private const MAX_RECORDED = 1000;
+
+    private int $count = 0;
+
+    /** @var list<array{item: ?string, reason: string}> */
+    private array $errors = [];
+
+    public function record(?string $item, string $reason): void
+    {
+        ++$this->count;
+
+        if (count($this->errors) < self::MAX_RECORDED) {
+            $this->errors[] = ['item' => $item, 'reason' => $reason];
+        }
+    }
+
+    public function count(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @return list<array{item: ?string, reason: string}>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Generator/FeedContextResultRecorder.php
+++ b/src/Generator/FeedContextResultRecorder.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Generator;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\Doctrine\ORMTrait;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Creates and persists a {@see FeedContextResultInterface} from a completed {@see GenerationResult}
+ * (§11). Uses the resource factory + ManagerRegistry so the concrete model stays overridable and
+ * the correct manager is resolved per entity.
+ */
+final class FeedContextResultRecorder implements FeedContextResultRecorderInterface
+{
+    use ORMTrait;
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly FactoryInterface $feedContextResultFactory,
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    public function record(FeedInterface $feed, string $contextKey, GenerationResult $result): FeedContextResultInterface
+    {
+        $feedContextResult = $this->feedContextResultFactory->createNew();
+        Assert::isInstanceOf($feedContextResult, FeedContextResultInterface::class);
+
+        $feedContextResult->setFeed($feed);
+        $feedContextResult->setContextKey($contextKey);
+        $feedContextResult->setItemCount($result->itemCount);
+        $feedContextResult->setExcludedCount($result->excludedCount);
+        $feedContextResult->setBytes($result->bytes);
+        $feedContextResult->setErrors($result->errors);
+
+        $manager = $this->getManager($feedContextResult);
+        $manager->persist($feedContextResult);
+        $manager->flush();
+
+        return $feedContextResult;
+    }
+}

--- a/src/Generator/FeedContextResultRecorderInterface.php
+++ b/src/Generator/FeedContextResultRecorderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Generator;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+
+interface FeedContextResultRecorderInterface
+{
+    /**
+     * Persist a {@see FeedContextResultInterface} capturing the outcome of one context's generation
+     * run (§11), so the excluded-item report and the publish gate have a durable record.
+     */
+    public function record(FeedInterface $feed, string $contextKey, GenerationResult $result): FeedContextResultInterface;
+}

--- a/src/Generator/FeedGenerator.php
+++ b/src/Generator/FeedGenerator.php
@@ -8,9 +8,11 @@ use League\Flysystem\FilesystemOperator;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Event\FeedItemBuiltEvent;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
+use Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface;
 use Setono\SyliusFeedPlugin\Filter\FilterSet;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
 use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
 use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
@@ -35,6 +37,8 @@ final class FeedGenerator implements FeedGeneratorInterface
         private readonly FormatRegistryInterface $formatRegistry,
         private readonly FeedWriterRegistryInterface $writerRegistry,
         private readonly FieldMappingEvaluatorInterface $fieldMappingEvaluator,
+        private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly LookupReferenceResolverInterface $lookupReferenceResolver,
         private readonly RequiredFieldsValidatorInterface $requiredFieldsValidator,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly UrlGeneratorInterface $urlGenerator,
@@ -68,11 +72,29 @@ final class FeedGenerator implements FeedGeneratorInterface
             $feedType = $this->feedTypeRegistry->get((string) $source->getFeedType());
             $availableFields = $feedType->getAvailableFields();
             $mappings = $this->resolveMappings($feed, $source);
+            $filterSet = new FilterSet($source->getFilters());
 
-            foreach ($feedType->getDataSource()->getItems($context, new FilterSet($source->getFilters())) as $entity) {
+            foreach ($feedType->getDataSource()->getItems($context, $filterSet) as $entity) {
                 $item = new FeedItem($entity, $context);
 
+                // Bind the source resolver up front so pre-filters can resolve raw source fields;
+                // mapping reuses the same (idempotent) binding. NOTE: all filters are evaluated per
+                // item — pushing `pre` filters into the data source query is a future optimization.
+                SourceResolverBinder::bind($item, $availableFields, $this->lookupReferenceResolver);
+
+                if (null !== $this->filterEvaluator->excludedBy($item, $filterSet->getPreFilters())) {
+                    ++$excludedCount;
+
+                    continue;
+                }
+
                 $this->fieldMappingEvaluator->apply($item, $mappings, $availableFields);
+
+                if (null !== $this->filterEvaluator->excludedBy($item, $filterSet->getPostFilters())) {
+                    ++$excludedCount;
+
+                    continue;
+                }
 
                 $this->eventDispatcher->dispatch(new FeedItemBuiltEvent($item));
 

--- a/src/Generator/FeedGenerator.php
+++ b/src/Generator/FeedGenerator.php
@@ -13,9 +13,7 @@ use Setono\SyliusFeedPlugin\Filter\FilterSet;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
-use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
-use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
-use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
+use Setono\SyliusFeedPlugin\Mapping\MappingResolverInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
 use Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface;
@@ -33,7 +31,7 @@ final class FeedGenerator implements FeedGeneratorInterface
 {
     public function __construct(
         private readonly FeedTypeRegistryInterface $feedTypeRegistry,
-        private readonly MappingPresetRegistryInterface $mappingPresetRegistry,
+        private readonly MappingResolverInterface $mappingResolver,
         private readonly FormatRegistryInterface $formatRegistry,
         private readonly FeedWriterRegistryInterface $writerRegistry,
         private readonly FieldMappingEvaluatorInterface $fieldMappingEvaluator,
@@ -72,7 +70,7 @@ final class FeedGenerator implements FeedGeneratorInterface
         foreach ($this->sortedSources($feed) as $source) {
             $feedType = $this->feedTypeRegistry->get((string) $source->getFeedType());
             $availableFields = $feedType->getAvailableFields();
-            $mappings = $this->resolveMappings($feed, $source);
+            $mappings = $this->mappingResolver->resolve($feed, $source);
             $filterSet = new FilterSet($source->getFilters());
 
             foreach ($feedType->getDataSource()->getItems($context, $filterSet) as $entity) {
@@ -150,33 +148,6 @@ final class FeedGenerator implements FeedGeneratorInterface
     }
 
     /**
-     * The admin-editable FeedField rows are the source of truth once a source has any; the matching
-     * MappingPreset is only the fallback for a source that was never seeded/edited (§10).
-     *
-     * @return list<FieldMapping>
-     */
-    private function resolveMappings(FeedInterface $feed, FeedSourceInterface $source): array
-    {
-        $fields = $source->getFields()->toArray();
-        if ([] !== $fields) {
-            usort(
-                $fields,
-                static fn (FeedFieldInterface $a, FeedFieldInterface $b): int => ($a->getPosition() ?? 0) <=> ($b->getPosition() ?? 0),
-            );
-
-            return array_map(FieldMapping::fromFeedField(...), $fields);
-        }
-
-        foreach ($this->mappingPresetRegistry->forFeedType((string) $source->getFeedType()) as $preset) {
-            if ($preset->getFormat() === $feed->getFormat()) {
-                return $preset->getMapping();
-            }
-        }
-
-        return [];
-    }
-
-    /**
      * The union of every source's output fields, in first-seen order — the CSV header.
      *
      * @return list<string>
@@ -185,7 +156,7 @@ final class FeedGenerator implements FeedGeneratorInterface
     {
         $header = [];
         foreach ($this->sortedSources($feed) as $source) {
-            foreach ($this->resolveMappings($feed, $source) as $mapping) {
+            foreach ($this->mappingResolver->resolve($feed, $source) as $mapping) {
                 $outputField = $mapping->getOutputField();
                 if (!in_array($outputField, $header, true)) {
                     $header[] = $outputField;

--- a/src/Generator/FeedGenerator.php
+++ b/src/Generator/FeedGenerator.php
@@ -18,7 +18,7 @@ use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
 use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
-use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface;
 use Setono\SyliusFeedPlugin\Writer\CsvWriterConfig;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -39,7 +39,7 @@ final class FeedGenerator implements FeedGeneratorInterface
         private readonly FieldMappingEvaluatorInterface $fieldMappingEvaluator,
         private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly LookupReferenceResolverInterface $lookupReferenceResolver,
-        private readonly RequiredFieldsValidatorInterface $requiredFieldsValidator,
+        private readonly FeedItemValidatorInterface $feedItemValidator,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly FilesystemOperator $feedFilesystem,
@@ -58,6 +58,7 @@ final class FeedGenerator implements FeedGeneratorInterface
             $config = $config->withHeader($this->unionHeader($feed));
         }
         $requiredFields = $format->getRequiredFields();
+        $itemValidationGroups = $format->getItemValidationGroups();
 
         $this->applyRequestContext($context);
 
@@ -66,7 +67,7 @@ final class FeedGenerator implements FeedGeneratorInterface
         $writer->writePreamble();
 
         $itemCount = 0;
-        $excludedCount = 0;
+        $exclusions = new ExclusionCollector();
 
         foreach ($this->sortedSources($feed) as $source) {
             $feedType = $this->feedTypeRegistry->get((string) $source->getFeedType());
@@ -75,31 +76,40 @@ final class FeedGenerator implements FeedGeneratorInterface
             $filterSet = new FilterSet($source->getFilters());
 
             foreach ($feedType->getDataSource()->getItems($context, $filterSet) as $entity) {
-                $item = new FeedItem($entity, $context);
+                $item = $feedType->createItem($entity, $context);
 
                 // Bind the source resolver up front so pre-filters can resolve raw source fields;
                 // mapping reuses the same (idempotent) binding. NOTE: all filters are evaluated per
                 // item — pushing `pre` filters into the data source query is a future optimization.
                 SourceResolverBinder::bind($item, $availableFields, $this->lookupReferenceResolver);
 
-                if (null !== $this->filterEvaluator->excludedBy($item, $filterSet->getPreFilters())) {
-                    ++$excludedCount;
+                $excludingPreFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPreFilters());
+                if (null !== $excludingPreFilter) {
+                    $exclusions->record($this->resolveItemIdentifier($item), sprintf('filter:pre:%s', (string) $excludingPreFilter->getField()));
 
                     continue;
                 }
 
                 $this->fieldMappingEvaluator->apply($item, $mappings, $availableFields);
 
-                if (null !== $this->filterEvaluator->excludedBy($item, $filterSet->getPostFilters())) {
-                    ++$excludedCount;
+                $excludingPostFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPostFilters());
+                if (null !== $excludingPostFilter) {
+                    $exclusions->record($this->resolveItemIdentifier($item), sprintf('filter:post:%s', (string) $excludingPostFilter->getField()));
 
                     continue;
                 }
 
                 $this->eventDispatcher->dispatch(new FeedItemBuiltEvent($item));
 
-                if ($item->isSkipped() || [] !== $this->requiredFieldsValidator->findMissingFields($item, $requiredFields)) {
-                    ++$excludedCount;
+                if ($item->isSkipped()) {
+                    $exclusions->record($this->resolveItemIdentifier($item), 'skipped');
+
+                    continue;
+                }
+
+                $violations = $this->feedItemValidator->validate($item, $requiredFields, $itemValidationGroups);
+                if ([] !== $violations) {
+                    $exclusions->record($this->resolveItemIdentifier($item), 'validation:' . implode('; ', $violations));
 
                     continue;
                 }
@@ -116,9 +126,27 @@ final class FeedGenerator implements FeedGeneratorInterface
 
         rewind($stream);
         $this->feedFilesystem->writeStream($path, $stream);
+        $stat = fstat($stream);
+        $bytes = false === $stat ? 0 : $stat['size'];
         fclose($stream);
 
-        return new GenerationResult($path, $itemCount, $excludedCount);
+        return new GenerationResult($path, $itemCount, $exclusions->count(), $bytes, $exclusions->errors());
+    }
+
+    /**
+     * The item's identity for exclusion reporting: its output id if the mapping has produced one,
+     * else null (§11). A pre-filter exclusion happens before mapping, so the id is usually null there.
+     */
+    private function resolveItemIdentifier(FeedItem $item): ?string
+    {
+        foreach (['g:id', 'id'] as $key) {
+            $value = $item->get($key);
+            if (is_scalar($value) && '' !== (string) $value) {
+                return (string) $value;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Generator/FieldMappingEvaluator.php
+++ b/src/Generator/FieldMappingEvaluator.php
@@ -32,17 +32,9 @@ final class FieldMappingEvaluator implements FieldMappingEvaluatorInterface
 
     public function apply(FeedItem $item, iterable $mappings, array $availableFields): void
     {
-        $entity = $item->getEntity();
-        $context = $item->getContext();
-        $item->setSourceResolver(function (string $field) use ($entity, $context, $availableFields): mixed {
-            if ($this->lookupReferenceResolver->supports($field)) {
-                return $this->lookupReferenceResolver->resolve($field, $entity, $context, $availableFields);
-            }
-
-            return isset($availableFields[$field])
-                ? $availableFields[$field]->getResolver()->resolve($entity, $context)
-                : null;
-        });
+        // Idempotent: the generator binds this up front (so pre-filters can resolve source fields);
+        // this call is the safety net when apply() runs standalone, e.g. in unit tests.
+        SourceResolverBinder::bind($item, $availableFields, $this->lookupReferenceResolver);
 
         foreach ($mappings as $mapping) {
             if (!$this->conditionSatisfied($mapping, $item)) {

--- a/src/Generator/GenerationResult.php
+++ b/src/Generator/GenerationResult.php
@@ -5,15 +5,21 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\Generator;
 
 /**
- * The outcome of generating one context's feed file: where it was written and how many items
- * were included vs excluded.
+ * The outcome of generating one context's feed file (§11): where it was written, how many items
+ * were included vs excluded, the size of the produced file, and a bounded sample of per-item
+ * exclusion reasons.
  */
 final class GenerationResult
 {
+    /**
+     * @param list<array{item: ?string, reason: string}> $errors
+     */
     public function __construct(
         public readonly string $path,
         public readonly int $itemCount,
         public readonly int $excludedCount,
+        public readonly int $bytes = 0,
+        public readonly array $errors = [],
     ) {
     }
 }

--- a/src/Generator/SourceResolverBinder.php
+++ b/src/Generator/SourceResolverBinder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Generator;
+
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
+use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
+
+/**
+ * Binds an item's on-demand source resolver — the closure that resolves a named source field /
+ * value resolver (incl. `attribute:` and `lookup:` references) against the item's entity+context
+ * (§10). Binding is idempotent (once per item) so it can be established up front by the generator
+ * (before pre-filters resolve raw source fields) and re-requested by the mapping evaluator without
+ * rebinding. Both the generator and FieldMappingEvaluator::apply() go through here so the closure
+ * is built the exact same way regardless of who binds first.
+ */
+final class SourceResolverBinder
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, FieldDefinition> $availableFields
+     */
+    public static function bind(FeedItem $item, array $availableFields, LookupReferenceResolverInterface $lookupReferenceResolver): void
+    {
+        if ($item->hasSourceResolver()) {
+            return;
+        }
+
+        $entity = $item->getEntity();
+        $context = $item->getContext();
+
+        $item->setSourceResolver(static function (string $field) use ($entity, $context, $availableFields, $lookupReferenceResolver): mixed {
+            if ($lookupReferenceResolver->supports($field)) {
+                return $lookupReferenceResolver->resolve($field, $entity, $context, $availableFields);
+            }
+
+            return isset($availableFields[$field])
+                ? $availableFields[$field]->getResolver()->resolve($entity, $context)
+                : null;
+        });
+    }
+}

--- a/src/Item/FeedItem.php
+++ b/src/Item/FeedItem.php
@@ -65,6 +65,16 @@ class FeedItem implements \IteratorAggregate, \ArrayAccess, \Countable
     }
 
     /**
+     * Whether an on-demand source resolver has already been bound (see $sourceResolver). Lets the
+     * binding be established once per item — up front by the generator (so pre-filters can resolve
+     * raw source fields) and re-requested by the mapping evaluator without rebinding.
+     */
+    public function hasSourceResolver(): bool
+    {
+        return null !== $this->sourceResolver;
+    }
+
+    /**
      * Resolve a named source field / value resolver against this item on demand. Returns null when
      * no resolver is bound or the name is unknown — a miss is never an error (§10).
      */

--- a/src/Mapping/MappingResolver.php
+++ b/src/Mapping/MappingResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Mapping;
+
+use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
+use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+
+/**
+ * @see MappingResolverInterface
+ */
+final class MappingResolver implements MappingResolverInterface
+{
+    public function __construct(private readonly MappingPresetRegistryInterface $mappingPresetRegistry)
+    {
+    }
+
+    public function resolve(FeedInterface $feed, FeedSourceInterface $source): array
+    {
+        $fields = $source->getFields()->toArray();
+        if ([] !== $fields) {
+            usort(
+                $fields,
+                static fn (FeedFieldInterface $a, FeedFieldInterface $b): int => ($a->getPosition() ?? 0) <=> ($b->getPosition() ?? 0),
+            );
+
+            return array_map(FieldMapping::fromFeedField(...), $fields);
+        }
+
+        foreach ($this->mappingPresetRegistry->forFeedType((string) $source->getFeedType()) as $preset) {
+            if ($preset->getFormat() === $feed->getFormat()) {
+                return $preset->getMapping();
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Mapping/MappingResolverInterface.php
+++ b/src/Mapping/MappingResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Mapping;
+
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+
+/**
+ * Resolves the ordered field mappings for one source of a feed (§10). The admin-editable FeedField
+ * rows are the source of truth once a source has any; the matching MappingPreset is the fallback
+ * for a source that was never seeded/edited. Shared by the generator and the dry-run preview so the
+ * two never diverge.
+ */
+interface MappingResolverInterface
+{
+    /**
+     * @return list<FieldMapping>
+     */
+    public function resolve(FeedInterface $feed, FeedSourceInterface $source): array;
+}

--- a/src/MessageHandler/GenerateFeedContextHandler.php
+++ b/src/MessageHandler/GenerateFeedContextHandler.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusFeedPlugin\MessageHandler;
 use Doctrine\Persistence\ManagerRegistry;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface;
 use Setono\SyliusFeedPlugin\Generator\FeedGeneratorInterface;
 use Setono\SyliusFeedPlugin\Message\Command\GenerateFeedContext;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
@@ -31,6 +32,7 @@ final class GenerateFeedContextHandler
         private readonly FeedRepositoryInterface $feedRepository,
         private readonly RepositoryInterface $channelRepository,
         private readonly FeedGeneratorInterface $feedGenerator,
+        private readonly FeedContextResultRecorderInterface $feedContextResultRecorder,
         private readonly Registry $workflowRegistry,
     ) {
         $this->managerRegistry = $managerRegistry;
@@ -43,8 +45,10 @@ final class GenerateFeedContextHandler
             return;
         }
 
+        $context = $this->buildContext($message);
+
         try {
-            $this->feedGenerator->generate($feed, $this->buildContext($message));
+            $result = $this->feedGenerator->generate($feed, $context);
         } catch (\Throwable $exception) {
             $this->fail($message->feed);
 
@@ -55,6 +59,10 @@ final class GenerateFeedContextHandler
         // was loaded moments ago, so it is guaranteed to still exist.
         $feed = $this->feedRepository->find($message->feed);
         Assert::isInstanceOf($feed, FeedInterface::class);
+
+        // Record the excluded-item report + size/count for this context now that generation
+        // finished, against the managed feed (§11).
+        $this->feedContextResultRecorder->record($feed, $context->key(), $result);
 
         $completed = $this->feedRepository->incrementCompletedContexts($feed);
         if (null !== $feed->getContextCount() && $completed >= $feed->getContextCount()) {

--- a/src/MessageHandler/GenerateFeedContextHandler.php
+++ b/src/MessageHandler/GenerateFeedContextHandler.php
@@ -7,21 +7,28 @@ namespace Setono\SyliusFeedPlugin\MessageHandler;
 use Doctrine\Persistence\ManagerRegistry;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Event\FeedPublishBlockedEvent;
 use Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface;
 use Setono\SyliusFeedPlugin\Generator\FeedGeneratorInterface;
 use Setono\SyliusFeedPlugin\Message\Command\GenerateFeedContext;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Publish\PublishGateInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
 use Setono\SyliusFeedPlugin\Repository\FeedRepositoryInterface;
 use Setono\SyliusFeedPlugin\Workflow\FeedGraph;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Workflow\Registry;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * Generates one context's feed file to temporary storage, then atomically counts it as completed;
- * the handler that finishes the last context completes the feed (§6.3). Because the generator
- * clears the entity manager while streaming, the completion bookkeeping re-fetches the feed.
+ * Generates one context's feed file to temporary (staging) storage, records the candidate result,
+ * then runs it through the publish gate (§6.6) to decide whether it may be promoted to the live feed
+ * (the promotion itself happens per-context on `complete`). Finally it counts the context as
+ * completed; the handler that finishes the last context completes the feed (§6.3). Because the
+ * generator clears the entity manager while streaming, the bookkeeping re-fetches the feed.
  */
 final class GenerateFeedContextHandler
 {
@@ -33,6 +40,9 @@ final class GenerateFeedContextHandler
         private readonly RepositoryInterface $channelRepository,
         private readonly FeedGeneratorInterface $feedGenerator,
         private readonly FeedContextResultRecorderInterface $feedContextResultRecorder,
+        private readonly FeedContextResultRepositoryInterface $feedContextResultRepository,
+        private readonly PublishGateInterface $publishGate,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Registry $workflowRegistry,
     ) {
         $this->managerRegistry = $managerRegistry;
@@ -61,12 +71,42 @@ final class GenerateFeedContextHandler
         Assert::isInstanceOf($feed, FeedInterface::class);
 
         // Record the excluded-item report + size/count for this context now that generation
-        // finished, against the managed feed (§11).
-        $this->feedContextResultRecorder->record($feed, $context->key(), $result);
+        // finished, against the managed feed (§11). The candidate starts out `pending`.
+        $contextKey = $context->key();
+        $candidate = $this->feedContextResultRecorder->record($feed, $contextKey, $result);
+
+        $this->gate($feed, $contextKey, $candidate);
 
         $completed = $this->feedRepository->incrementCompletedContexts($feed);
         if (null !== $feed->getContextCount() && $completed >= $feed->getContextCount()) {
             $this->transition($feed, FeedGraph::TRANSITION_COMPLETE);
+        }
+    }
+
+    /**
+     * Runs the freshly recorded candidate through the publish gate against the last published
+     * baseline (§6.6), stamps the outcome onto the candidate, and notifies listeners when the gate
+     * blocked promotion or a `warn` guardrail flagged a concern.
+     */
+    private function gate(FeedInterface $feed, string $contextKey, FeedContextResultInterface $candidate): void
+    {
+        $baseline = $this->feedContextResultRepository->findLatestPublished($feed, $contextKey);
+
+        $guardrails = $feed->getPublishConfig()['guardrails'] ?? [];
+        $decision = $this->publishGate->evaluate($candidate, $baseline, is_array($guardrails) ? $guardrails : []);
+
+        $candidate->setPublishState(
+            $decision->blocked
+                ? FeedContextResultInterface::PUBLISH_STATE_BLOCKED
+                : FeedContextResultInterface::PUBLISH_STATE_PUBLISHED,
+        );
+        $candidate->setPublishCheck([] === $decision->reasons ? null : $decision->reasons);
+        $this->getManager($candidate)->flush();
+
+        if ($decision->blocked || [] !== $decision->reasons) {
+            $this->eventDispatcher->dispatch(
+                new FeedPublishBlockedEvent($feed, $contextKey, $decision->reasons, $decision->blocked),
+            );
         }
     }
 

--- a/src/Model/Feed.php
+++ b/src/Model/Feed.php
@@ -30,6 +30,9 @@ class Feed implements FeedInterface
     /** @var array<string, mixed> */
     protected array $formatConfig = [];
 
+    /** @var array<string, mixed> */
+    protected array $publishConfig = [];
+
     /** @var Collection<int, FeedSourceInterface> */
     protected Collection $sources;
 
@@ -141,6 +144,16 @@ class Feed implements FeedInterface
     public function setFormatConfig(array $formatConfig): void
     {
         $this->formatConfig = $formatConfig;
+    }
+
+    public function getPublishConfig(): array
+    {
+        return $this->publishConfig;
+    }
+
+    public function setPublishConfig(array $publishConfig): void
+    {
+        $this->publishConfig = $publishConfig;
     }
 
     public function getSources(): Collection

--- a/src/Model/FeedContextResult.php
+++ b/src/Model/FeedContextResult.php
@@ -21,6 +21,11 @@ class FeedContextResult implements FeedContextResultInterface
     /** @var list<array{item: ?string, reason: string}> */
     protected array $errors = [];
 
+    protected string $publishState = FeedContextResultInterface::PUBLISH_STATE_PENDING;
+
+    /** @var list<string>|null */
+    protected ?array $publishCheck = null;
+
     protected \DateTimeInterface $createdAt;
 
     public function __construct()
@@ -96,6 +101,36 @@ class FeedContextResult implements FeedContextResultInterface
     public function addError(?string $item, string $reason): void
     {
         $this->errors[] = ['item' => $item, 'reason' => $reason];
+    }
+
+    public function getPublishState(): string
+    {
+        return $this->publishState;
+    }
+
+    public function setPublishState(string $publishState): void
+    {
+        $this->publishState = $publishState;
+    }
+
+    public function getPublishCheck(): ?array
+    {
+        return $this->publishCheck;
+    }
+
+    public function setPublishCheck(?array $publishCheck): void
+    {
+        $this->publishCheck = $publishCheck;
+    }
+
+    public function isPublished(): bool
+    {
+        return FeedContextResultInterface::PUBLISH_STATE_PUBLISHED === $this->publishState;
+    }
+
+    public function isBlocked(): bool
+    {
+        return FeedContextResultInterface::PUBLISH_STATE_BLOCKED === $this->publishState;
     }
 
     public function getCreatedAt(): \DateTimeInterface

--- a/src/Model/FeedContextResult.php
+++ b/src/Model/FeedContextResult.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+class FeedContextResult implements FeedContextResultInterface
+{
+    protected ?int $id = null;
+
+    protected ?FeedInterface $feed = null;
+
+    protected ?string $contextKey = null;
+
+    protected int $itemCount = 0;
+
+    protected int $excludedCount = 0;
+
+    protected int $bytes = 0;
+
+    /** @var list<array{item: ?string, reason: string}> */
+    protected array $errors = [];
+
+    protected \DateTimeInterface $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFeed(): ?FeedInterface
+    {
+        return $this->feed;
+    }
+
+    public function setFeed(?FeedInterface $feed): void
+    {
+        $this->feed = $feed;
+    }
+
+    public function getContextKey(): ?string
+    {
+        return $this->contextKey;
+    }
+
+    public function setContextKey(?string $contextKey): void
+    {
+        $this->contextKey = $contextKey;
+    }
+
+    public function getItemCount(): int
+    {
+        return $this->itemCount;
+    }
+
+    public function setItemCount(int $itemCount): void
+    {
+        $this->itemCount = $itemCount;
+    }
+
+    public function getExcludedCount(): int
+    {
+        return $this->excludedCount;
+    }
+
+    public function setExcludedCount(int $excludedCount): void
+    {
+        $this->excludedCount = $excludedCount;
+    }
+
+    public function getBytes(): int
+    {
+        return $this->bytes;
+    }
+
+    public function setBytes(int $bytes): void
+    {
+        $this->bytes = $bytes;
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public function setErrors(array $errors): void
+    {
+        $this->errors = $errors;
+    }
+
+    public function addError(?string $item, string $reason): void
+    {
+        $this->errors[] = ['item' => $item, 'reason' => $reason];
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/src/Model/FeedContextResultInterface.php
+++ b/src/Model/FeedContextResultInterface.php
@@ -13,6 +13,22 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface FeedContextResultInterface extends ResourceInterface
 {
+    /**
+     * The candidate has been recorded but not yet evaluated by the publish gate (§6.6).
+     */
+    public const PUBLISH_STATE_PENDING = 'pending';
+
+    /**
+     * The candidate passed the publish gate and its file was promoted to canonical storage.
+     */
+    public const PUBLISH_STATE_PUBLISHED = 'published';
+
+    /**
+     * The candidate tripped a `block`-severity guardrail; its file is retained in staging and the
+     * previously published canonical file is kept live.
+     */
+    public const PUBLISH_STATE_BLOCKED = 'blocked';
+
     public function getId(): ?int;
 
     public function getFeed(): ?FeedInterface;
@@ -54,6 +70,29 @@ interface FeedContextResultInterface extends ResourceInterface
     public function setErrors(array $errors): void;
 
     public function addError(?string $item, string $reason): void;
+
+    /**
+     * The publish-gate outcome for this candidate (§6.6): one of the PUBLISH_STATE_* constants.
+     */
+    public function getPublishState(): string;
+
+    public function setPublishState(string $publishState): void;
+
+    /**
+     * The reasons recorded by the publish gate when guardrails tripped, or null when none did.
+     *
+     * @return list<string>|null
+     */
+    public function getPublishCheck(): ?array;
+
+    /**
+     * @param list<string>|null $publishCheck
+     */
+    public function setPublishCheck(?array $publishCheck): void;
+
+    public function isPublished(): bool;
+
+    public function isBlocked(): bool;
 
     public function getCreatedAt(): \DateTimeInterface;
 

--- a/src/Model/FeedContextResultInterface.php
+++ b/src/Model/FeedContextResultInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Model;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+/**
+ * A persisted report of one context's generation run (§11): how many items were written vs
+ * excluded, the size of the produced file, and a bounded sample of per-item exclusion reasons.
+ * The most recent row per (feed, contextKey) feeds the publish gate in a later chunk.
+ */
+interface FeedContextResultInterface extends ResourceInterface
+{
+    public function getId(): ?int;
+
+    public function getFeed(): ?FeedInterface;
+
+    public function setFeed(?FeedInterface $feed): void;
+
+    /**
+     * The {@see \Setono\SyliusFeedPlugin\Context\FeedContext::key()} the run produced, e.g. "web_en_US_USD".
+     */
+    public function getContextKey(): ?string;
+
+    public function setContextKey(?string $contextKey): void;
+
+    public function getItemCount(): int;
+
+    public function setItemCount(int $itemCount): void;
+
+    public function getExcludedCount(): int;
+
+    public function setExcludedCount(int $excludedCount): void;
+
+    /**
+     * The byte size of the produced feed file.
+     */
+    public function getBytes(): int;
+
+    public function setBytes(int $bytes): void;
+
+    /**
+     * A bounded sample of per-item exclusion reasons collected during generation.
+     *
+     * @return list<array{item: ?string, reason: string}>
+     */
+    public function getErrors(): array;
+
+    /**
+     * @param list<array{item: ?string, reason: string}> $errors
+     */
+    public function setErrors(array $errors): void;
+
+    public function addError(?string $item, string $reason): void;
+
+    public function getCreatedAt(): \DateTimeInterface;
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): void;
+}

--- a/src/Model/FeedInterface.php
+++ b/src/Model/FeedInterface.php
@@ -53,6 +53,20 @@ interface FeedInterface extends ResourceInterface, CodeAwareInterface, Toggleabl
     public function setFormatConfig(array $formatConfig): void;
 
     /**
+     * The publish-gate configuration (§6.6): the guardrails evaluated before a freshly generated
+     * context is promoted from staging to canonical storage. Shape:
+     * {guardrails: list<{type: string, params: array<string, mixed>, severity: 'block'|'warn'}>}.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPublishConfig(): array;
+
+    /**
+     * @param array<string, mixed> $publishConfig
+     */
+    public function setPublishConfig(array $publishConfig): void;
+
+    /**
      * @return Collection<int, FeedSourceInterface>
      */
     public function getSources(): Collection;

--- a/src/Preview/PreviewFunnel.php
+++ b/src/Preview/PreviewFunnel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Preview;
+
+/**
+ * The stage-by-stage survivor counts of a dry-run preview over the sampled source items (§11).
+ * Every count is monotonically non-increasing from {@see $source} down to {@see $included}, and
+ * each excluded item is attributed to exactly one stage, so the drops between adjacent stages
+ * explain the whole funnel.
+ */
+final class PreviewFunnel
+{
+    public function __construct(
+        public readonly int $source,
+        public readonly int $afterPreFilters,
+        public readonly int $afterMappingValidation,
+        public readonly int $afterPostFilters,
+        public readonly int $included,
+    ) {
+    }
+}

--- a/src/Preview/PreviewResult.php
+++ b/src/Preview/PreviewResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Preview;
+
+/**
+ * The outcome of a dry-run preview (§11): the {@see PreviewFunnel} of stage counts, a bounded
+ * sample of the mapped output bags that would be included, and a bounded sample of the excluded
+ * items with the reason each was dropped. Nothing is written — this is purely diagnostic.
+ */
+final class PreviewResult
+{
+    /**
+     * @param list<array<string, mixed>> $included the mapped output bags of included sample items
+     * @param list<array{item: ?string, reason: string}> $excluded excluded sample items + why
+     */
+    public function __construct(
+        public readonly PreviewFunnel $funnel,
+        public readonly array $included,
+        public readonly array $excluded,
+    ) {
+    }
+}

--- a/src/Preview/PreviewService.php
+++ b/src/Preview/PreviewService.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Preview;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Event\FeedItemBuiltEvent;
+use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
+use Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface;
+use Setono\SyliusFeedPlugin\Filter\FilterSet;
+use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
+use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface;
+use Setono\SyliusFeedPlugin\Generator\SourceResolverBinder;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface;
+use Setono\SyliusFeedPlugin\Mapping\MappingResolverInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @see PreviewServiceInterface
+ *
+ * Runs the exact pipeline of {@see \Setono\SyliusFeedPlugin\Generator\FeedGenerator} (same mapping
+ * resolution, filter evaluation, item-built event and validation) but never opens a writer and
+ * never touches storage — the item output stays in memory as a diagnostic sample (§11).
+ */
+final class PreviewService implements PreviewServiceInterface
+{
+    /**
+     * How many source items previewItem() scans per source while looking for a matching id — a
+     * bound so the single-item tester cannot walk an unbounded catalog.
+     */
+    private const PREVIEW_ITEM_SCAN_CAP = 1000;
+
+    public function __construct(
+        private readonly FeedTypeRegistryInterface $feedTypeRegistry,
+        private readonly MappingResolverInterface $mappingResolver,
+        private readonly FormatRegistryInterface $formatRegistry,
+        private readonly FieldMappingEvaluatorInterface $fieldMappingEvaluator,
+        private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly LookupReferenceResolverInterface $lookupReferenceResolver,
+        private readonly FeedItemValidatorInterface $feedItemValidator,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function preview(FeedInterface $feed, FeedContext $context, int $limit = 50): PreviewResult
+    {
+        $limit = max(1, $limit);
+
+        $format = $this->formatRegistry->get((string) $feed->getFormat());
+        $requiredFields = $format->getRequiredFields();
+        $itemValidationGroups = $format->getItemValidationGroups();
+
+        $sampled = 0;
+        $preExcluded = 0;
+        $postExcluded = 0;
+        // The item-built event (skip) and validation both drop after mapping — grouped as one stage.
+        $mappingValidationExcluded = 0;
+        $includedCount = 0;
+
+        $included = [];
+        $excluded = [];
+
+        foreach ($this->sortedSources($feed) as $feedSource) {
+            $feedType = $this->feedTypeRegistry->get((string) $feedSource->getFeedType());
+            $availableFields = $feedType->getAvailableFields();
+            $mappings = $this->mappingResolver->resolve($feed, $feedSource);
+            $filterSet = new FilterSet($feedSource->getFilters());
+
+            $sampledFromSource = 0;
+            foreach ($feedType->getDataSource()->getItems($context, $filterSet) as $entity) {
+                if ($sampledFromSource >= $limit) {
+                    break;
+                }
+                ++$sampledFromSource;
+                ++$sampled;
+
+                $item = $feedType->createItem($entity, $context);
+                SourceResolverBinder::bind($item, $availableFields, $this->lookupReferenceResolver);
+
+                $excludingPreFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPreFilters());
+                if (null !== $excludingPreFilter) {
+                    ++$preExcluded;
+                    $excluded[] = ['item' => $this->resolveItemIdentifier($item), 'reason' => sprintf('filter:pre:%s', (string) $excludingPreFilter->getField())];
+
+                    continue;
+                }
+
+                $this->fieldMappingEvaluator->apply($item, $mappings, $availableFields);
+
+                $excludingPostFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPostFilters());
+                if (null !== $excludingPostFilter) {
+                    ++$postExcluded;
+                    $excluded[] = ['item' => $this->resolveItemIdentifier($item), 'reason' => sprintf('filter:post:%s', (string) $excludingPostFilter->getField())];
+
+                    continue;
+                }
+
+                $this->eventDispatcher->dispatch(new FeedItemBuiltEvent($item));
+
+                if ($item->isSkipped()) {
+                    ++$mappingValidationExcluded;
+                    $excluded[] = ['item' => $this->resolveItemIdentifier($item), 'reason' => 'skipped'];
+
+                    continue;
+                }
+
+                $violations = $this->feedItemValidator->validate($item, $requiredFields, $itemValidationGroups);
+                if ([] !== $violations) {
+                    ++$mappingValidationExcluded;
+                    $excluded[] = ['item' => $this->resolveItemIdentifier($item), 'reason' => 'validation:' . implode('; ', $violations)];
+
+                    continue;
+                }
+
+                ++$includedCount;
+                $included[] = $item->all();
+            }
+        }
+
+        $afterPreFilters = $sampled - $preExcluded;
+        $afterMappingValidation = $afterPreFilters - $mappingValidationExcluded;
+        $afterPostFilters = $afterMappingValidation - $postExcluded;
+
+        $funnel = new PreviewFunnel($sampled, $afterPreFilters, $afterMappingValidation, $afterPostFilters, $includedCount);
+
+        return new PreviewResult(
+            $funnel,
+            array_slice($included, 0, $limit),
+            array_slice($excluded, 0, $limit),
+        );
+    }
+
+    public function previewItem(FeedInterface $feed, FeedContext $context, string $id): array
+    {
+        $format = $this->formatRegistry->get((string) $feed->getFormat());
+        $requiredFields = $format->getRequiredFields();
+        $itemValidationGroups = $format->getItemValidationGroups();
+
+        foreach ($this->sortedSources($feed) as $feedSource) {
+            $feedType = $this->feedTypeRegistry->get((string) $feedSource->getFeedType());
+            $availableFields = $feedType->getAvailableFields();
+            $mappings = $this->mappingResolver->resolve($feed, $feedSource);
+            $filterSet = new FilterSet($feedSource->getFilters());
+
+            $scanned = 0;
+            foreach ($feedType->getDataSource()->getItems($context, $filterSet) as $entity) {
+                if ($scanned >= self::PREVIEW_ITEM_SCAN_CAP) {
+                    break;
+                }
+                ++$scanned;
+
+                $item = $feedType->createItem($entity, $context);
+                SourceResolverBinder::bind($item, $availableFields, $this->lookupReferenceResolver);
+
+                // The pre-filter is evaluated before mapping in the real pipeline, but we always map
+                // so the output id resolves and we can match even a pre-filtered item.
+                $excludingPreFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPreFilters());
+                $this->fieldMappingEvaluator->apply($item, $mappings, $availableFields);
+
+                if ($this->resolveItemIdentifier($item) !== $id) {
+                    continue;
+                }
+
+                if (null !== $excludingPreFilter) {
+                    return $this->itemVerdict(false, $item->all(), sprintf('filter:pre:%s', (string) $excludingPreFilter->getField()));
+                }
+
+                $excludingPostFilter = $this->filterEvaluator->excludedBy($item, $filterSet->getPostFilters());
+                if (null !== $excludingPostFilter) {
+                    return $this->itemVerdict(false, $item->all(), sprintf('filter:post:%s', (string) $excludingPostFilter->getField()));
+                }
+
+                $this->eventDispatcher->dispatch(new FeedItemBuiltEvent($item));
+
+                if ($item->isSkipped()) {
+                    return $this->itemVerdict(false, $item->all(), 'skipped');
+                }
+
+                $violations = $this->feedItemValidator->validate($item, $requiredFields, $itemValidationGroups);
+                if ([] !== $violations) {
+                    return $this->itemVerdict(false, $item->all(), 'validation:' . implode('; ', $violations));
+                }
+
+                return $this->itemVerdict(true, $item->all(), null);
+            }
+        }
+
+        return $this->itemVerdict(false, [], 'not_found');
+    }
+
+    /**
+     * @param array<string, mixed> $output
+     *
+     * @return array{included: bool, output: array<string, mixed>, reason: ?string}
+     */
+    private function itemVerdict(bool $included, array $output, ?string $reason): array
+    {
+        return ['included' => $included, 'output' => $output, 'reason' => $reason];
+    }
+
+    /**
+     * The item's identity for reporting: its output id if the mapping has produced one, else null
+     * (mirrors the generator, §11).
+     */
+    private function resolveItemIdentifier(FeedItem $item): ?string
+    {
+        foreach (['g:id', 'id'] as $key) {
+            $value = $item->get($key);
+            if (is_scalar($value) && '' !== (string) $value) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<FeedSourceInterface>
+     */
+    private function sortedSources(FeedInterface $feed): array
+    {
+        $sources = array_values($feed->getSources()->toArray());
+        usort(
+            $sources,
+            static fn (FeedSourceInterface $a, FeedSourceInterface $b): int => ($a->getPosition() ?? 0) <=> ($b->getPosition() ?? 0),
+        );
+
+        return $sources;
+    }
+}

--- a/src/Preview/PreviewServiceInterface.php
+++ b/src/Preview/PreviewServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Preview;
+
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+
+/**
+ * Runs the generator's per-item pipeline over a bounded sample of a feed's source items without
+ * writing anything (§11), so an admin can see the include/exclude funnel, the mapped output of
+ * sample items, and why items are dropped before committing to a full run.
+ */
+interface PreviewServiceInterface
+{
+    /**
+     * Preview at most $limit source items per source through the full pipeline (pre-filter → map →
+     * post-filter → item-built event → validation), returning the funnel and bounded samples.
+     */
+    public function preview(FeedInterface $feed, FeedContext $context, int $limit = 50): PreviewResult;
+
+    /**
+     * Single-item tester: find the source item whose resolved `id`/`g:id` equals $id within a
+     * bounded scan of the data source and report whether it would be included, its mapped output,
+     * and — when excluded — the rule that dropped it.
+     *
+     * @return array{included: bool, output: array<string, mixed>, reason: ?string}
+     */
+    public function previewItem(FeedInterface $feed, FeedContext $context, string $id): array;
+}

--- a/src/Publish/AbstractGuardrail.php
+++ b/src/Publish/AbstractGuardrail.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+/**
+ * Base for guardrails that read numeric thresholds from the untrusted, JSON-sourced params map.
+ * Coerces values defensively so a malformed config yields the default rather than a type error.
+ */
+abstract class AbstractGuardrail implements GuardrailInterface
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    protected function intParam(array $params, string $key, int $default = 0): int
+    {
+        $value = $params[$key] ?? $default;
+
+        return is_numeric($value) ? (int) $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    protected function floatParam(array $params, string $key, float $default = 0.0): float
+    {
+        $value = $params[$key] ?? $default;
+
+        return is_numeric($value) ? (float) $value : $default;
+    }
+}

--- a/src/Publish/GuardrailInterface.php
+++ b/src/Publish/GuardrailInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * A single publish-gate check (§6.6). Given the freshly generated candidate result and, when it
+ * exists, the previously published baseline for the same context, it decides whether the candidate
+ * looks wrong enough that it should not silently replace the live feed.
+ *
+ * Collected into the {@see GuardrailRegistry} via the `setono_sylius_feed.guardrail` tag.
+ */
+interface GuardrailInterface
+{
+    /**
+     * e.g. "min_items", "max_drop_pct", "non_empty", "min_bytes", "max_exclusion_pct",
+     * "max_growth_pct".
+     */
+    public function getType(): string;
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return bool true when the guardrail is TRIPPED (the candidate looks wrong)
+     */
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool;
+}

--- a/src/Publish/GuardrailRegistry.php
+++ b/src/Publish/GuardrailRegistry.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Registry\Registry;
+
+/**
+ * @extends Registry<GuardrailInterface>
+ */
+final class GuardrailRegistry extends Registry implements GuardrailRegistryInterface
+{
+    public function get(string $type): GuardrailInterface
+    {
+        return $this->getByKey($type);
+    }
+
+    /**
+     * @param GuardrailInterface $item
+     */
+    protected function getKey(object $item): string
+    {
+        return $item->getType();
+    }
+}

--- a/src/Publish/GuardrailRegistryInterface.php
+++ b/src/Publish/GuardrailRegistryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Registry\RegistryInterface;
+
+/**
+ * @extends RegistryInterface<GuardrailInterface>
+ */
+interface GuardrailRegistryInterface extends RegistryInterface
+{
+    public function get(string $type): GuardrailInterface;
+}

--- a/src/Publish/MaxDropPctGuardrail.php
+++ b/src/Publish/MaxDropPctGuardrail.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate's item count fell more than `params['pct']` percent below the baseline
+ * (§6.6) — the classic "50k → 5k" collapse (a 90% drop). Without a baseline there is nothing to
+ * compare against, so it never trips.
+ */
+final class MaxDropPctGuardrail extends AbstractGuardrail
+{
+    public function getType(): string
+    {
+        return 'max_drop_pct';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        if (null === $baseline) {
+            return false;
+        }
+
+        $baselineCount = $baseline->getItemCount();
+        if ($baselineCount <= 0) {
+            return false;
+        }
+
+        $candidateCount = $candidate->getItemCount();
+        if ($candidateCount >= $baselineCount) {
+            return false;
+        }
+
+        $dropPct = ($baselineCount - $candidateCount) / $baselineCount * 100;
+
+        return $dropPct > $this->floatParam($params, 'pct');
+    }
+}

--- a/src/Publish/MaxExclusionPctGuardrail.php
+++ b/src/Publish/MaxExclusionPctGuardrail.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate's exclusion ratio — `excludedCount / (itemCount + excludedCount)` —
+ * exceeds `params['pct']` percent (§6.6). The absolute threshold always applies; when a baseline is
+ * present the ratio must additionally have jumped beyond the baseline's ratio, so a feed that has
+ * always excluded a large (but stable) share of items does not trip on every run.
+ */
+final class MaxExclusionPctGuardrail extends AbstractGuardrail
+{
+    public function getType(): string
+    {
+        return 'max_exclusion_pct';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        $candidateRatio = $this->ratio($candidate);
+        if ($candidateRatio <= $this->floatParam($params, 'pct')) {
+            return false;
+        }
+
+        if (null !== $baseline && $candidateRatio <= $this->ratio($baseline)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * The excluded share of the run as a 0-100 percentage; 0 when nothing was processed.
+     */
+    private function ratio(FeedContextResultInterface $result): float
+    {
+        $total = $result->getItemCount() + $result->getExcludedCount();
+        if ($total <= 0) {
+            return 0.0;
+        }
+
+        return $result->getExcludedCount() / $total * 100;
+    }
+}

--- a/src/Publish/MaxGrowthPctGuardrail.php
+++ b/src/Publish/MaxGrowthPctGuardrail.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate's item count grew more than `params['pct']` percent above the baseline
+ * (§6.6) — a sudden, implausible expansion (e.g. a broken filter that stopped excluding). Without a
+ * baseline there is nothing to compare against, so it never trips.
+ */
+final class MaxGrowthPctGuardrail extends AbstractGuardrail
+{
+    public function getType(): string
+    {
+        return 'max_growth_pct';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        if (null === $baseline) {
+            return false;
+        }
+
+        $baselineCount = $baseline->getItemCount();
+        if ($baselineCount <= 0) {
+            return false;
+        }
+
+        $candidateCount = $candidate->getItemCount();
+        if ($candidateCount <= $baselineCount) {
+            return false;
+        }
+
+        $growthPct = ($candidateCount - $baselineCount) / $baselineCount * 100;
+
+        return $growthPct > $this->floatParam($params, 'pct');
+    }
+}

--- a/src/Publish/MinBytesGuardrail.php
+++ b/src/Publish/MinBytesGuardrail.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate file is smaller than `params['bytes']` (§6.6) — catches truncated or
+ * near-empty output even when the item count looks plausible.
+ */
+final class MinBytesGuardrail extends AbstractGuardrail
+{
+    public function getType(): string
+    {
+        return 'min_bytes';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        return $candidate->getBytes() < $this->intParam($params, 'bytes');
+    }
+}

--- a/src/Publish/MinItemsGuardrail.php
+++ b/src/Publish/MinItemsGuardrail.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate contains fewer than `params['min']` items — an absolute floor that is
+ * independent of any baseline (§6.6).
+ */
+final class MinItemsGuardrail extends AbstractGuardrail
+{
+    public function getType(): string
+    {
+        return 'min_items';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        return $candidate->getItemCount() < $this->intParam($params, 'min');
+    }
+}

--- a/src/Publish/NonEmptyGuardrail.php
+++ b/src/Publish/NonEmptyGuardrail.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Tripped when the candidate contains no items at all (§6.6). A degenerate but common failure mode
+ * worth a dedicated guardrail so it can be blocked without configuring a minimum.
+ */
+final class NonEmptyGuardrail implements GuardrailInterface
+{
+    public function getType(): string
+    {
+        return 'non_empty';
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $params,
+    ): bool {
+        return 0 === $candidate->getItemCount();
+    }
+}

--- a/src/Publish/PublishDecision.php
+++ b/src/Publish/PublishDecision.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+/**
+ * The outcome of running a context's candidate through the publish gate (§6.6): whether promotion
+ * to canonical storage is blocked, and the human-readable reasons every tripped guardrail recorded
+ * (including non-blocking `warn` guardrails).
+ */
+final class PublishDecision
+{
+    /**
+     * @param list<string> $reasons
+     */
+    public function __construct(
+        public readonly bool $blocked,
+        public readonly array $reasons = [],
+    ) {
+    }
+}

--- a/src/Publish/PublishGate.php
+++ b/src/Publish/PublishGate.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+/**
+ * Runs a context's candidate through its configured guardrails (§6.6). A tripped `block` guardrail
+ * blocks promotion; a tripped `warn` guardrail only records a reason. Unknown or malformed guardrail
+ * entries are skipped so a stale/typo'd config never hard-fails a run, and an empty list means
+ * "no gate". The config originates from persisted JSON, so every entry is treated as untrusted.
+ */
+final class PublishGate implements PublishGateInterface
+{
+    public const SEVERITY_BLOCK = 'block';
+
+    public const SEVERITY_WARN = 'warn';
+
+    public function __construct(
+        private readonly GuardrailRegistryInterface $guardrailRegistry,
+    ) {
+    }
+
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $guardrails,
+    ): PublishDecision {
+        $blocked = false;
+        $reasons = [];
+
+        foreach ($guardrails as $guardrail) {
+            if (!is_array($guardrail)) {
+                continue;
+            }
+
+            $type = $guardrail['type'] ?? null;
+            if (!is_string($type) || !$this->guardrailRegistry->has($type)) {
+                continue;
+            }
+
+            $severity = $guardrail['severity'] ?? self::SEVERITY_BLOCK;
+            if (!is_string($severity)) {
+                $severity = self::SEVERITY_BLOCK;
+            }
+
+            $tripped = $this->guardrailRegistry
+                ->get($type)
+                ->evaluate($candidate, $baseline, $this->toParams($guardrail['params'] ?? []));
+
+            if (!$tripped) {
+                continue;
+            }
+
+            $reasons[] = sprintf('%s: guardrail tripped (severity: %s)', $type, $severity);
+
+            if (self::SEVERITY_BLOCK === $severity) {
+                $blocked = true;
+            }
+        }
+
+        return new PublishDecision($blocked, $reasons);
+    }
+
+    /**
+     * Coerces an untrusted config value into a string-keyed params map for a guardrail.
+     *
+     * @return array<string, mixed>
+     */
+    private function toParams(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $params = [];
+        foreach ($value as $key => $item) {
+            $params[(string) $key] = $item;
+        }
+
+        return $params;
+    }
+}

--- a/src/Publish/PublishGateInterface.php
+++ b/src/Publish/PublishGateInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Publish;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+
+interface PublishGateInterface
+{
+    /**
+     * Evaluates the configured guardrails for one context's candidate against its baseline (§6.6).
+     * An empty guardrail list means "no gate" and never blocks. The list is the raw, untrusted
+     * `publishConfig['guardrails']` value; each entry is expected to be
+     * `{type: string, params?: array, severity?: 'block'|'warn'}` and anything else is skipped.
+     *
+     * @param array<array-key, mixed> $guardrails
+     */
+    public function evaluate(
+        FeedContextResultInterface $candidate,
+        ?FeedContextResultInterface $baseline,
+        array $guardrails,
+    ): PublishDecision;
+}

--- a/src/Repository/FeedContextResultRepository.php
+++ b/src/Repository/FeedContextResultRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Repository;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+
+class FeedContextResultRepository extends EntityRepository implements FeedContextResultRepositoryInterface
+{
+    public function findLatestPublished(FeedInterface $feed, string $contextKey): ?FeedContextResultInterface
+    {
+        $result = $this->createQueryBuilder('o')
+            ->andWhere('o.feed = :feed')
+            ->andWhere('o.contextKey = :contextKey')
+            ->setParameter('feed', $feed)
+            ->setParameter('contextKey', $contextKey)
+            ->orderBy('o.createdAt', 'DESC')
+            ->addOrderBy('o.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof FeedContextResultInterface ? $result : null;
+    }
+}

--- a/src/Repository/FeedContextResultRepository.php
+++ b/src/Repository/FeedContextResultRepository.php
@@ -15,6 +15,24 @@ class FeedContextResultRepository extends EntityRepository implements FeedContex
         $result = $this->createQueryBuilder('o')
             ->andWhere('o.feed = :feed')
             ->andWhere('o.contextKey = :contextKey')
+            ->andWhere('o.publishState = :publishState')
+            ->setParameter('feed', $feed)
+            ->setParameter('contextKey', $contextKey)
+            ->setParameter('publishState', FeedContextResultInterface::PUBLISH_STATE_PUBLISHED)
+            ->orderBy('o.createdAt', 'DESC')
+            ->addOrderBy('o.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof FeedContextResultInterface ? $result : null;
+    }
+
+    public function findLatestForContext(FeedInterface $feed, string $contextKey): ?FeedContextResultInterface
+    {
+        $result = $this->createQueryBuilder('o')
+            ->andWhere('o.feed = :feed')
+            ->andWhere('o.contextKey = :contextKey')
             ->setParameter('feed', $feed)
             ->setParameter('contextKey', $contextKey)
             ->orderBy('o.createdAt', 'DESC')

--- a/src/Repository/FeedContextResultRepositoryInterface.php
+++ b/src/Repository/FeedContextResultRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Repository;
+
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @extends RepositoryInterface<FeedContextResultInterface>
+ */
+interface FeedContextResultRepositoryInterface extends RepositoryInterface
+{
+    /**
+     * The most recent result recorded for the given feed and context key (§11) — the row the
+     * publish gate consults for the previously served output. Ordered by creation time, newest first.
+     */
+    public function findLatestPublished(FeedInterface $feed, string $contextKey): ?FeedContextResultInterface;
+}

--- a/src/Repository/FeedContextResultRepositoryInterface.php
+++ b/src/Repository/FeedContextResultRepositoryInterface.php
@@ -14,8 +14,17 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 interface FeedContextResultRepositoryInterface extends RepositoryInterface
 {
     /**
-     * The most recent result recorded for the given feed and context key (§11) — the row the
-     * publish gate consults for the previously served output. Ordered by creation time, newest first.
+     * The most recent *published* result for the given feed and context key (§6.6) — the baseline
+     * the publish gate compares a new candidate against. Filters on
+     * {@see FeedContextResultInterface::PUBLISH_STATE_PUBLISHED} so a just-recorded pending candidate
+     * is never its own baseline. Ordered by creation time, newest first.
      */
     public function findLatestPublished(FeedInterface $feed, string $contextKey): ?FeedContextResultInterface;
+
+    /**
+     * The most recent result for the given feed and context key regardless of publish state (§6.6) —
+     * used by the promotion step to decide whether a staged file was published or blocked. Ordered
+     * by creation time, newest first.
+     */
+    public function findLatestForContext(FeedInterface $feed, string $contextKey): ?FeedContextResultInterface;
 }

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -69,6 +69,15 @@ sylius_grid:
                                 route: setono_sylius_feed_admin_feed_results
                                 parameters:
                                     id: resource.id
+                    preview:
+                        type: default
+                        label: setono_sylius_feed.ui.preview
+                        icon: search
+                        options:
+                            link:
+                                route: setono_sylius_feed_admin_feed_preview
+                                parameters:
+                                    id: resource.id
                     update:
                         type: update
                     delete:

--- a/src/Resources/config/doctrine/model/Feed.orm.xml
+++ b/src/Resources/config/doctrine/model/Feed.orm.xml
@@ -15,6 +15,7 @@
         <field name="format" type="string" nullable="true"/>
         <field name="state" type="string"/>
         <field name="formatConfig" column="format_config" type="json"/>
+        <field name="publishConfig" column="publish_config" type="json"/>
         <field name="lastGeneratedAt" column="last_generated_at" type="datetime_immutable" nullable="true"/>
         <field name="contextCount" column="context_count" type="integer" nullable="true"/>
         <field name="completedContextCount" column="completed_context_count" type="integer"/>

--- a/src/Resources/config/doctrine/model/FeedContextResult.orm.xml
+++ b/src/Resources/config/doctrine/model/FeedContextResult.orm.xml
@@ -19,6 +19,8 @@
         <field name="excludedCount" column="excluded_count" type="integer"/>
         <field name="bytes" column="bytes" type="integer"/>
         <field name="errors" column="errors" type="json"/>
+        <field name="publishState" column="publish_state" type="string"/>
+        <field name="publishCheck" column="publish_check" type="json" nullable="true"/>
         <field name="createdAt" column="created_at" type="datetime_immutable"/>
 
         <many-to-one field="feed" target-entity="Setono\SyliusFeedPlugin\Model\FeedInterface">

--- a/src/Resources/config/doctrine/model/FeedContextResult.orm.xml
+++ b/src/Resources/config/doctrine/model/FeedContextResult.orm.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<doctrine-mapping xmlns="http://doctrine.apache.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine.apache.org/schemas/orm/doctrine-mapping
+                  http://doctrine.apache.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Setono\SyliusFeedPlugin\Model\FeedContextResult" table="setono_sylius_feed__feed_context_result">
+        <indexes>
+            <index name="setono_sylius_feed__fcr_feed_context_idx" columns="feed_id,context_key"/>
+        </indexes>
+
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="contextKey" column="context_key" type="string" nullable="true"/>
+        <field name="itemCount" column="item_count" type="integer"/>
+        <field name="excludedCount" column="excluded_count" type="integer"/>
+        <field name="bytes" column="bytes" type="integer"/>
+        <field name="errors" column="errors" type="json"/>
+        <field name="createdAt" column="created_at" type="datetime_immutable"/>
+
+        <many-to-one field="feed" target-entity="Setono\SyliusFeedPlugin\Model\FeedInterface">
+            <join-column name="feed_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+    </entity>
+</doctrine-mapping>

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -24,6 +24,14 @@ setono_sylius_feed_admin_feed_results:
     defaults:
         _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\FeedResultsAction'
 
+setono_sylius_feed_admin_feed_publish_context:
+    path: /feeds/{id}/publish/{contextKey}
+    methods: [GET]
+    defaults:
+        _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\PublishContextAnywayAction'
+    requirements:
+        contextKey: '[^/]+'
+
 setono_sylius_feed_admin_lookup_table:
     resource: |
         alias: setono_sylius_feed.lookup_table

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -24,6 +24,12 @@ setono_sylius_feed_admin_feed_results:
     defaults:
         _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\FeedResultsAction'
 
+setono_sylius_feed_admin_feed_preview:
+    path: /feeds/{id}/preview
+    methods: [GET]
+    defaults:
+        _controller: 'Setono\SyliusFeedPlugin\Controller\Admin\PreviewFeedAction'
+
 setono_sylius_feed_admin_feed_publish_context:
     path: /feeds/{id}/publish/{contextKey}
     methods: [GET]

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,6 +18,7 @@
         <import resource="services/context.xml"/>
         <import resource="services/feed_type.xml"/>
         <import resource="services/validator.xml"/>
+        <import resource="services/publish.xml"/>
         <import resource="services/generator.xml"/>
         <import resource="services/messenger.xml"/>
         <import resource="services/event_subscriber.xml"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,6 +6,7 @@
         <import resource="services/registry.xml"/>
         <import resource="services/reference.xml"/>
         <import resource="services/operator.xml"/>
+        <import resource="services/filter.xml"/>
         <import resource="services/lookup.xml"/>
         <import resource="services/scripting.xml"/>
         <import resource="services/transformation.xml"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,6 +20,7 @@
         <import resource="services/validator.xml"/>
         <import resource="services/publish.xml"/>
         <import resource="services/generator.xml"/>
+        <import resource="services/preview.xml"/>
         <import resource="services/messenger.xml"/>
         <import resource="services/event_subscriber.xml"/>
         <import resource="services/command.xml"/>

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -7,6 +7,9 @@
         <service id="Setono\SyliusFeedPlugin\Command\ProcessFeedCommand">
             <argument type="service" id="setono_sylius_feed.repository.feed"/>
             <argument type="service" id="setono_sylius_feed.command_bus"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Context\ContextFactoryInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface"/>
             <tag name="console.command"/>
         </service>
     </services>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -30,5 +30,15 @@
             <argument type="service" id="twig"/>
             <tag name="controller.service_arguments"/>
         </service>
+
+        <service id="Setono\SyliusFeedPlugin\Controller\Admin\PublishContextAnywayAction">
+            <argument type="service" id="doctrine"/>
+            <argument type="service" id="setono_sylius_feed.repository.feed"/>
+            <argument type="service" id="setono_sylius_feed.repository.feed_context_result"/>
+            <argument type="service" id="setono_sylius_feed.storage.feed_tmp"/>
+            <argument type="service" id="setono_sylius_feed.storage.feed"/>
+            <argument type="service" id="router"/>
+            <tag name="controller.service_arguments"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -31,6 +31,15 @@
             <tag name="controller.service_arguments"/>
         </service>
 
+        <service id="Setono\SyliusFeedPlugin\Controller\Admin\PreviewFeedAction">
+            <argument type="service" id="setono_sylius_feed.repository.feed"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Context\ContextFactoryInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface"/>
+            <argument type="service" id="twig"/>
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="Setono\SyliusFeedPlugin\Controller\Admin\PublishContextAnywayAction">
             <argument type="service" id="doctrine"/>
             <argument type="service" id="setono_sylius_feed.repository.feed"/>

--- a/src/Resources/config/services/event_subscriber.xml
+++ b/src/Resources/config/services/event_subscriber.xml
@@ -7,6 +7,7 @@
         <service id="Setono\SyliusFeedPlugin\EventSubscriber\MoveGeneratedFeedSubscriber">
             <argument type="service" id="setono_sylius_feed.storage.feed_tmp"/>
             <argument type="service" id="setono_sylius_feed.storage.feed"/>
+            <argument type="service" id="setono_sylius_feed.repository.feed_context_result"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/config/services/filter.xml
+++ b/src/Resources/config/services/filter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Setono\SyliusFeedPlugin\Filter\FilterEvaluator">
+            <argument type="service" id="Setono\SyliusFeedPlugin\Reference\ReferenceResolverInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface" alias="Setono\SyliusFeedPlugin\Filter\FilterEvaluator"/>
+    </services>
+</container>

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -29,6 +29,11 @@
             <tag name="form.type"/>
         </service>
 
+        <service id="Setono\SyliusFeedPlugin\Form\Type\FeedFilterType">
+            <argument type="service" id="Setono\SyliusFeedPlugin\Operator\OperatorRegistryInterface"/>
+            <tag name="form.type"/>
+        </service>
+
         <service id="Setono\SyliusFeedPlugin\Form\Type\LookupTableType">
             <argument>%setono_sylius_feed.model.lookup_table.class%</argument>
             <tag name="form.type"/>

--- a/src/Resources/config/services/generator.xml
+++ b/src/Resources/config/services/generator.xml
@@ -23,6 +23,8 @@
             <argument type="service" id="Setono\SyliusFeedPlugin\Format\FormatRegistryInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="router"/>

--- a/src/Resources/config/services/generator.xml
+++ b/src/Resources/config/services/generator.xml
@@ -4,6 +4,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Setono\SyliusFeedPlugin\Mapping\MappingResolver">
+            <argument type="service" id="Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Mapping\MappingResolverInterface" alias="Setono\SyliusFeedPlugin\Mapping\MappingResolver"/>
+
         <service id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator"/>
         <service id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface" alias="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator"/>
 
@@ -25,7 +30,7 @@
 
         <service id="Setono\SyliusFeedPlugin\Generator\FeedGenerator">
             <argument type="service" id="Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface"/>
-            <argument type="service" id="Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Mapping\MappingResolverInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Format\FormatRegistryInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface"/>

--- a/src/Resources/config/services/generator.xml
+++ b/src/Resources/config/services/generator.xml
@@ -7,6 +7,12 @@
         <service id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator"/>
         <service id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface" alias="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator"/>
 
+        <service id="Setono\SyliusFeedPlugin\Validator\FeedItemValidator">
+            <argument type="service" id="validator"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface" alias="Setono\SyliusFeedPlugin\Validator\FeedItemValidator"/>
+
         <service id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator">
             <argument type="service" id="Setono\SyliusFeedPlugin\Transformation\TransformationChainInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Reference\ReferenceResolverInterface"/>
@@ -25,11 +31,17 @@
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface"/>
-            <argument type="service" id="Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidatorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="router"/>
             <argument type="service" id="setono_sylius_feed.storage.feed_tmp"/>
         </service>
         <service id="Setono\SyliusFeedPlugin\Generator\FeedGeneratorInterface" alias="Setono\SyliusFeedPlugin\Generator\FeedGenerator"/>
+
+        <service id="Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorder">
+            <argument type="service" id="doctrine"/>
+            <argument type="service" id="setono_sylius_feed.factory.feed_context_result"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface" alias="Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorder"/>
     </services>
 </container>

--- a/src/Resources/config/services/messenger.xml
+++ b/src/Resources/config/services/messenger.xml
@@ -19,6 +19,9 @@
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FeedGeneratorInterface"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface"/>
+            <argument type="service" id="setono_sylius_feed.repository.feed_context_result"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Publish\PublishGateInterface"/>
+            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="workflow.registry"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Resources/config/services/messenger.xml
+++ b/src/Resources/config/services/messenger.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="setono_sylius_feed.repository.feed"/>
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FeedGeneratorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface"/>
             <argument type="service" id="workflow.registry"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Resources/config/services/preview.xml
+++ b/src/Resources/config/services/preview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Setono\SyliusFeedPlugin\Preview\PreviewService">
+            <argument type="service" id="Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Mapping\MappingResolverInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Format\FormatRegistryInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluatorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Filter\FilterEvaluatorInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Lookup\LookupReferenceResolverInterface"/>
+            <argument type="service" id="Setono\SyliusFeedPlugin\Validator\FeedItemValidatorInterface"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface" alias="Setono\SyliusFeedPlugin\Preview\PreviewService"/>
+
+        <service id="Setono\SyliusFeedPlugin\Audit\FeedAuditService"/>
+        <service id="Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface" alias="Setono\SyliusFeedPlugin\Audit\FeedAuditService"/>
+    </services>
+</container>

--- a/src/Resources/config/services/publish.xml
+++ b/src/Resources/config/services/publish.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Setono\SyliusFeedPlugin\Publish\MinItemsGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\MaxDropPctGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\NonEmptyGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\MinBytesGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\MaxExclusionPctGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\MaxGrowthPctGuardrail">
+            <tag name="setono_sylius_feed.guardrail"/>
+        </service>
+
+        <service id="Setono\SyliusFeedPlugin\Publish\PublishGate">
+            <argument type="service" id="Setono\SyliusFeedPlugin\Publish\GuardrailRegistryInterface"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\PublishGateInterface" alias="Setono\SyliusFeedPlugin\Publish\PublishGate"/>
+    </services>
+</container>

--- a/src/Resources/config/services/registry.xml
+++ b/src/Resources/config/services/registry.xml
@@ -43,5 +43,10 @@
             <argument type="tagged_iterator" tag="setono_sylius_feed.format"/>
         </service>
         <service id="Setono\SyliusFeedPlugin\Format\FormatRegistryInterface" alias="Setono\SyliusFeedPlugin\Format\FormatRegistry"/>
+
+        <service id="Setono\SyliusFeedPlugin\Publish\GuardrailRegistry" public="true">
+            <argument type="tagged_iterator" tag="setono_sylius_feed.guardrail"/>
+        </service>
+        <service id="Setono\SyliusFeedPlugin\Publish\GuardrailRegistryInterface" alias="Setono\SyliusFeedPlugin\Publish\GuardrailRegistry"/>
     </services>
 </container>

--- a/src/Resources/config/validation/GoogleShoppingItem.xml
+++ b/src/Resources/config/validation/GoogleShoppingItem.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Setono\SyliusFeedPlugin\Item\Google\GoogleShoppingItem">
+        <getter property="id">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.id.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="title">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.title.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+            <constraint name="Length">
+                <option name="max">150</option>
+                <option name="maxMessage">setono_sylius_feed.google_shopping_item.title.max_length</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="description">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.description.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="link">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.link.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="imageLink">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.image_link.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="availability">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.availability.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="price">
+            <constraint name="NotBlank">
+                <option name="message">setono_sylius_feed.google_shopping_item.price.not_blank</option>
+                <option name="groups">
+                    <value>Default</value>
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </getter>
+    </class>
+</constraint-mapping>

--- a/src/Resources/translations/flashes.en.yaml
+++ b/src/Resources/translations/flashes.en.yaml
@@ -1,5 +1,6 @@
 setono_sylius_feed:
     feed:
         generation_dispatched: Feed generation has been dispatched
+        context_published: The blocked context has been published
     lookup_table:
         refreshed: Lookup table has been refreshed

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -18,6 +18,32 @@ setono_sylius_feed:
         file: File
         size: Size
         no_results: This feed has not been generated yet
+        preview: Preview
+        preview_context: Previewing context
+        funnel: Include funnel
+        funnel_source: Sampled
+        funnel_after_pre_filters: After pre-filters
+        funnel_after_mapping_validation: After mapping & validation
+        funnel_after_post_filters: After post-filters
+        funnel_included: Included
+        audit: Audit
+        fill_rates: Fill rate
+        soft_warnings: Soft warnings
+        distributions: Distributions
+        included_sample: Included sample
+        excluded_sample: Excluded sample
+        no_included_items: No items would be included in this preview
+        no_excluded_items: No items were excluded in this preview
+        item: Item
+        field: Field
+        value: Value
+        count: Count
+        type: Type
+        reason: Reason
+        warning:
+            title_too_long: Title longer than 150 characters
+            description_contains_html: Description still contains HTML tags
+            price_empty: Price is zero or empty
     form:
         feed:
             name: Name

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -31,6 +31,20 @@ setono_sylius_feed:
         feed_source:
             feed_type: Feed type
             fields: Field mappings
+            filters: Filters
+        feed_filter:
+            field: Field
+            operator: Operator
+            value: Value
+            value_help: 'The value to compare against — a field name, an earlier output field, or a quoted literal (e.g. ''out_of_stock''). Leave empty for operators that take no value (e.g. empty / not_empty).'
+            action: Action
+            stage: Stage
+            action_choices:
+                include: Include matching
+                exclude: Exclude matching
+            stage_choices:
+                pre: Before mapping
+                post: After mapping
         feed_field:
             output_field: Output field
             source_type: Source type

--- a/src/Resources/translations/validators.en.yaml
+++ b/src/Resources/translations/validators.en.yaml
@@ -1,3 +1,21 @@
 setono_sylius_feed:
     feed:
         resolve_required_fields_before_enabling: 'Resolve every field that requires input (set its source and clear the "requires input" flag) before enabling this feed.'
+    validation:
+        missing_field: 'The required field is missing or empty.'
+    google_shopping_item:
+        id:
+            not_blank: 'The item id (g:id) must not be blank.'
+        title:
+            not_blank: 'The item title (g:title) must not be blank.'
+            max_length: 'The item title (g:title) must not be longer than {{ limit }} characters.'
+        description:
+            not_blank: 'The item description (g:description) must not be blank.'
+        link:
+            not_blank: 'The item link (g:link) must not be blank.'
+        image_link:
+            not_blank: 'The item image link (g:image_link) must not be blank.'
+        availability:
+            not_blank: 'The item availability (g:availability) must not be blank.'
+        price:
+            not_blank: 'The item price (g:price) must not be blank.'

--- a/src/Resources/views/admin/feed/preview.html.twig
+++ b/src/Resources/views/admin/feed/preview.html.twig
@@ -1,0 +1,154 @@
+{% extends '@SyliusAdmin/layout.html.twig' %}
+
+{% block content %}
+    <div class="ui segment">
+        <h1 class="ui header">{{ 'setono_sylius_feed.ui.preview'|trans }} — {{ feed.code }}</h1>
+
+        <div class="ui small basic label">{{ 'setono_sylius_feed.ui.preview_context'|trans }}: {{ context.key }}</div>
+
+        <h2 class="ui header">{{ 'setono_sylius_feed.ui.funnel'|trans }}</h2>
+        <table class="ui very basic collapsing table">
+            <tbody>
+                <tr>
+                    <td>{{ 'setono_sylius_feed.ui.funnel_source'|trans }}</td>
+                    <td>{{ preview.funnel.source }}</td>
+                </tr>
+                <tr>
+                    <td>{{ 'setono_sylius_feed.ui.funnel_after_pre_filters'|trans }}</td>
+                    <td>{{ preview.funnel.afterPreFilters }}</td>
+                </tr>
+                <tr>
+                    <td>{{ 'setono_sylius_feed.ui.funnel_after_mapping_validation'|trans }}</td>
+                    <td>{{ preview.funnel.afterMappingValidation }}</td>
+                </tr>
+                <tr>
+                    <td>{{ 'setono_sylius_feed.ui.funnel_after_post_filters'|trans }}</td>
+                    <td>{{ preview.funnel.afterPostFilters }}</td>
+                </tr>
+                <tr>
+                    <td><strong>{{ 'setono_sylius_feed.ui.funnel_included'|trans }}</strong></td>
+                    <td><strong>{{ preview.funnel.included }}</strong></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h2 class="ui header">{{ 'setono_sylius_feed.ui.audit'|trans }}</h2>
+
+        <h3 class="ui header">{{ 'setono_sylius_feed.ui.fill_rates'|trans }}</h3>
+        <table class="ui very basic table">
+            <thead>
+                <tr>
+                    <th>{{ 'setono_sylius_feed.ui.field'|trans }}</th>
+                    <th>{{ 'setono_sylius_feed.ui.fill_rates'|trans }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for field, rate in audit.fillRates %}
+                    <tr>
+                        <td>{{ field }}</td>
+                        <td>{{ (rate * 100)|round(1) }}%</td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="2">{{ 'setono_sylius_feed.ui.no_included_items'|trans }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        {% if audit.warnings is not empty %}
+            <h3 class="ui header">{{ 'setono_sylius_feed.ui.soft_warnings'|trans }}</h3>
+            <table class="ui very basic table">
+                <thead>
+                    <tr>
+                        <th>{{ 'setono_sylius_feed.ui.type'|trans }}</th>
+                        <th>{{ 'setono_sylius_feed.ui.field'|trans }}</th>
+                        <th>{{ 'setono_sylius_feed.ui.count'|trans }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for warning in audit.warnings %}
+                        <tr>
+                            <td>{{ ('setono_sylius_feed.ui.warning.' ~ warning.type)|trans }}</td>
+                            <td>{{ warning.field }}</td>
+                            <td>{{ warning.count }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+
+        {% if audit.distributions is not empty %}
+            <h3 class="ui header">{{ 'setono_sylius_feed.ui.distributions'|trans }}</h3>
+            {% for field, values in audit.distributions %}
+                <h4 class="ui header">{{ field }}</h4>
+                <table class="ui very basic collapsing table">
+                    <thead>
+                        <tr>
+                            <th>{{ 'setono_sylius_feed.ui.value'|trans }}</th>
+                            <th>{{ 'setono_sylius_feed.ui.count'|trans }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for value, count in values %}
+                            <tr>
+                                <td>{{ value }}</td>
+                                <td>{{ count }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endfor %}
+        {% endif %}
+
+        <h2 class="ui header">{{ 'setono_sylius_feed.ui.included_sample'|trans }}</h2>
+        <div style="overflow-x: auto;">
+            <table class="ui very basic table">
+                <thead>
+                    <tr>
+                        {% for column in columns %}
+                            <th>{{ column }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for bag in preview.included %}
+                        <tr>
+                            {% for column in columns %}
+                                <td>{{ bag[column] is iterable ? bag[column]|join(', ') : bag[column] }}</td>
+                            {% endfor %}
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td colspan="{{ columns|length ?: 1 }}">{{ 'setono_sylius_feed.ui.no_included_items'|trans }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        <h2 class="ui header">{{ 'setono_sylius_feed.ui.excluded_sample'|trans }}</h2>
+        <table class="ui very basic table">
+            <thead>
+                <tr>
+                    <th>{{ 'setono_sylius_feed.ui.item'|trans }}</th>
+                    <th>{{ 'setono_sylius_feed.ui.reason'|trans }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in preview.excluded %}
+                    <tr>
+                        <td>{{ row.item ?? '—' }}</td>
+                        <td>{{ row.reason }}</td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="2">{{ 'setono_sylius_feed.ui.no_excluded_items'|trans }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <a class="ui button" href="{{ path('setono_sylius_feed_admin_feed_index') }}">{{ 'sylius.ui.back'|trans }}</a>
+    </div>
+{% endblock %}

--- a/src/Validator/FeedItemValidator.php
+++ b/src/Validator/FeedItemValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Validator;
+
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Validates a per-item object for feed inclusion (§11): it runs the item's typed Symfony
+ * constraints (a typed subclass like GoogleShoppingItem carries the spec's constraints; a plain
+ * FeedItem has none) and, on top of that, the generic required-field fallback for the format. The
+ * two are merged and deduplicated into a flat list of violation messages / translation keys.
+ */
+final class FeedItemValidator implements FeedItemValidatorInterface
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        private readonly RequiredFieldsValidatorInterface $requiredFieldsValidator,
+    ) {
+    }
+
+    public function validate(FeedItem $item, array $requiredFields, array $validationGroups = ['Default']): array
+    {
+        $messages = [];
+
+        // Only run the typed constraints when the format opted in; otherwise a typed item (e.g. a
+        // GoogleShoppingItem produced by the product_variant source) rendered under a non-Google
+        // format would be rejected for lacking g:* fields it was never meant to carry.
+        if ([] !== $validationGroups) {
+            foreach ($this->validator->validate($item, null, $validationGroups) as $violation) {
+                $template = $violation->getMessageTemplate();
+                $messages[] = '' !== $template ? $template : (string) $violation->getMessage();
+            }
+        }
+
+        foreach ($this->requiredFieldsValidator->findMissingFields($item, $requiredFields) as $field) {
+            $messages[] = 'setono_sylius_feed.validation.missing_field: ' . $field;
+        }
+
+        return array_values(array_unique($messages));
+    }
+}

--- a/src/Validator/FeedItemValidatorInterface.php
+++ b/src/Validator/FeedItemValidatorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Validator;
+
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+
+interface FeedItemValidatorInterface
+{
+    /**
+     * Validate a per-item object against both its typed-item Symfony constraints (e.g. the Google
+     * Shopping spec on {@see \Setono\SyliusFeedPlugin\Item\Google\GoogleShoppingItem}) and the
+     * generic required-field fallback for the given format (§11).
+     *
+     * The typed constraints only run when $validationGroups is non-empty (the format opts in via
+     * {@see \Setono\SyliusFeedPlugin\Format\FormatInterface::getItemValidationGroups()}), so a typed
+     * item rendered under a non-matching format is not spuriously rejected; the required-field
+     * fallback always runs.
+     *
+     * @param list<string> $requiredFields
+     * @param list<string> $validationGroups
+     *
+     * @return list<string> the (deduplicated) violation messages / translation keys; empty when valid
+     */
+    public function validate(FeedItem $item, array $requiredFields, array $validationGroups = ['Default']): array;
+}

--- a/tests/Functional/FeedContextResultTest.php
+++ b/tests/Functional/FeedContextResultTest.php
@@ -13,49 +13,67 @@ use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
 
 /**
- * Proves the FeedContextResult resource is mapped and persistable end to end (§11): the recorder
- * writes a result against a real feed and the repository reads back the most recent one per
- * (feed, contextKey) via findLatestPublished. Uses the database (rolled back by dama).
+ * Proves the FeedContextResult resource is mapped and persistable end to end (§11) and that the
+ * publish-gate lookups behave (§6.6): findLatestPublished only sees `published` rows (so a pending
+ * candidate is never its own baseline), while findLatestForContext returns the most recent row
+ * regardless of state. Uses the database (rolled back by dama).
  */
 final class FeedContextResultTest extends FunctionalTestCase
 {
     /**
      * @test
      */
-    public function it_records_a_result_and_reads_back_the_latest_per_context(): void
+    public function it_does_not_treat_a_pending_candidate_as_its_own_baseline(): void
+    {
+        $feed = $this->persistFeed();
+        $repository = $this->repository();
+
+        // A freshly recorded candidate is `pending`...
+        $candidate = $this->recorder()->record($feed, 'web_en_US_USD', new GenerationResult('google/web_en_US_USD.xml', 5, 2, 512, []));
+
+        // ...so it is not yet a published baseline, but it is the latest result for the context.
+        self::assertNull($repository->findLatestPublished($feed, 'web_en_US_USD'));
+        self::assertSame($candidate->getId(), $repository->findLatestForContext($feed, 'web_en_US_USD')?->getId());
+        self::assertNull($repository->findLatestForContext($feed, 'does_not_exist'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_latest_published_row_as_the_baseline(): void
     {
         $feed = $this->persistFeed();
         $recorder = $this->recorder();
-
-        $recorder->record($feed, 'web_en_US_USD', new GenerationResult(
-            'google/web_en_US_USD.xml',
-            5,
-            2,
-            512,
-            [['item' => 'SKU-9', 'reason' => 'validation:setono_sylius_feed.google_shopping_item.title.not_blank']],
-        ));
-
-        // a later run for the same context supersedes the first
-        $recorder->record($feed, 'web_en_US_USD', new GenerationResult('google/web_en_US_USD.xml', 7, 0, 700, []));
-
-        // a different context is stored independently
-        $recorder->record($feed, 'web_da_DK_DKK', new GenerationResult('google/web_da_DK_DKK.xml', 1, 0, 64, []));
-
         $repository = $this->repository();
+        $manager = $this->entityManager();
 
-        $latest = $repository->findLatestPublished($feed, 'web_en_US_USD');
-        self::assertInstanceOf(FeedContextResultInterface::class, $latest);
-        self::assertSame(7, $latest->getItemCount());
-        self::assertSame(0, $latest->getExcludedCount());
-        self::assertSame(700, $latest->getBytes());
-        self::assertSame([], $latest->getErrors());
-        self::assertSame($feed->getId(), $latest->getFeed()?->getId());
+        // Publish a first run for the context.
+        $first = $recorder->record($feed, 'web_en_US_USD', new GenerationResult('google/web_en_US_USD.xml', 5, 2, 512, []));
+        $first->setPublishState(FeedContextResultInterface::PUBLISH_STATE_PUBLISHED);
+        $manager->flush();
 
-        $otherContext = $repository->findLatestPublished($feed, 'web_da_DK_DKK');
-        self::assertInstanceOf(FeedContextResultInterface::class, $otherContext);
-        self::assertSame(1, $otherContext->getItemCount());
+        $baseline = $repository->findLatestPublished($feed, 'web_en_US_USD');
+        self::assertInstanceOf(FeedContextResultInterface::class, $baseline);
+        self::assertSame($first->getId(), $baseline->getId());
 
-        self::assertNull($repository->findLatestPublished($feed, 'does_not_exist'));
+        // A later run supersedes the first as the latest candidate, but while it is still pending the
+        // baseline remains the previously published row.
+        $second = $recorder->record($feed, 'web_en_US_USD', new GenerationResult('google/web_en_US_USD.xml', 7, 0, 700, []));
+        self::assertSame($second->getId(), $repository->findLatestForContext($feed, 'web_en_US_USD')?->getId());
+        self::assertSame($first->getId(), $repository->findLatestPublished($feed, 'web_en_US_USD')?->getId());
+
+        // Publishing the second run makes it the new baseline.
+        $second->setPublishState(FeedContextResultInterface::PUBLISH_STATE_PUBLISHED);
+        $manager->flush();
+        $newBaseline = $repository->findLatestPublished($feed, 'web_en_US_USD');
+        self::assertInstanceOf(FeedContextResultInterface::class, $newBaseline);
+        self::assertSame(7, $newBaseline->getItemCount());
+        self::assertSame(700, $newBaseline->getBytes());
+        self::assertSame($feed->getId(), $newBaseline->getFeed()?->getId());
+
+        // A different context is stored independently.
+        $recorder->record($feed, 'web_da_DK_DKK', new GenerationResult('google/web_da_DK_DKK.xml', 1, 0, 64, []));
+        self::assertSame(1, $repository->findLatestForContext($feed, 'web_da_DK_DKK')?->getItemCount());
     }
 
     private function persistFeed(): FeedInterface

--- a/tests/Functional/FeedContextResultTest.php
+++ b/tests/Functional/FeedContextResultTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Setono\SyliusFeedPlugin\Generator\FeedContextResultRecorderInterface;
+use Setono\SyliusFeedPlugin\Generator\GenerationResult;
+use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
+
+/**
+ * Proves the FeedContextResult resource is mapped and persistable end to end (§11): the recorder
+ * writes a result against a real feed and the repository reads back the most recent one per
+ * (feed, contextKey) via findLatestPublished. Uses the database (rolled back by dama).
+ */
+final class FeedContextResultTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function it_records_a_result_and_reads_back_the_latest_per_context(): void
+    {
+        $feed = $this->persistFeed();
+        $recorder = $this->recorder();
+
+        $recorder->record($feed, 'web_en_US_USD', new GenerationResult(
+            'google/web_en_US_USD.xml',
+            5,
+            2,
+            512,
+            [['item' => 'SKU-9', 'reason' => 'validation:setono_sylius_feed.google_shopping_item.title.not_blank']],
+        ));
+
+        // a later run for the same context supersedes the first
+        $recorder->record($feed, 'web_en_US_USD', new GenerationResult('google/web_en_US_USD.xml', 7, 0, 700, []));
+
+        // a different context is stored independently
+        $recorder->record($feed, 'web_da_DK_DKK', new GenerationResult('google/web_da_DK_DKK.xml', 1, 0, 64, []));
+
+        $repository = $this->repository();
+
+        $latest = $repository->findLatestPublished($feed, 'web_en_US_USD');
+        self::assertInstanceOf(FeedContextResultInterface::class, $latest);
+        self::assertSame(7, $latest->getItemCount());
+        self::assertSame(0, $latest->getExcludedCount());
+        self::assertSame(700, $latest->getBytes());
+        self::assertSame([], $latest->getErrors());
+        self::assertSame($feed->getId(), $latest->getFeed()?->getId());
+
+        $otherContext = $repository->findLatestPublished($feed, 'web_da_DK_DKK');
+        self::assertInstanceOf(FeedContextResultInterface::class, $otherContext);
+        self::assertSame(1, $otherContext->getItemCount());
+
+        self::assertNull($repository->findLatestPublished($feed, 'does_not_exist'));
+    }
+
+    private function persistFeed(): FeedInterface
+    {
+        $feed = new Feed();
+        $feed->setCode('feed-context-result-' . bin2hex(random_bytes(4)));
+
+        $manager = $this->entityManager();
+        $manager->persist($feed);
+        $manager->flush();
+
+        return $feed;
+    }
+
+    private function recorder(): FeedContextResultRecorderInterface
+    {
+        $recorder = self::getContainer()->get(FeedContextResultRecorderInterface::class);
+        self::assertInstanceOf(FeedContextResultRecorderInterface::class, $recorder);
+
+        return $recorder;
+    }
+
+    private function repository(): FeedContextResultRepositoryInterface
+    {
+        $repository = self::getContainer()->get('setono_sylius_feed.repository.feed_context_result');
+        self::assertInstanceOf(FeedContextResultRepositoryInterface::class, $repository);
+
+        return $repository;
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $manager = self::getContainer()->get('doctrine.orm.entity_manager');
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+
+        return $manager;
+    }
+}

--- a/tests/Functional/MessageHandler/PublishGateFlowTest.php
+++ b/tests/Functional/MessageHandler/PublishGateFlowTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Functional\MessageHandler;
+
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Setono\SyliusFeedPlugin\Message\Command\ProcessFeed;
+use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSource;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
+use Setono\SyliusFeedPlugin\Tests\Functional\FunctionalTestCase;
+use Setono\SyliusFeedPlugin\Workflow\FeedGraph;
+use Sylius\Component\Core\Model\Channel;
+use Sylius\Component\Core\Model\ChannelPricing;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Core\Model\ProductImage;
+use Sylius\Component\Core\Model\ProductVariant;
+use Sylius\Component\Currency\Model\Currency;
+use Sylius\Component\Locale\Model\Locale;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * End-to-end publish gate (§6.6): a feed whose candidate trips a `block` guardrail must complete
+ * without overwriting the live canonical file. The candidate is recorded as `blocked`, its staging
+ * file is retained for inspection, and the previously served file is kept live.
+ */
+final class PublishGateFlowTest extends FunctionalTestCase
+{
+    private const CONTEXT = 'web_en_us_usd';
+
+    private const LIVE_CONTENT = '<rss>OLD-LIVE-FEED</rss>';
+
+    protected function tearDown(): void
+    {
+        foreach (['setono_sylius_feed.storage.feed', 'setono_sylius_feed.storage.feed_tmp'] as $id) {
+            $filesystem = self::getContainer()->get($id);
+            if ($filesystem instanceof FilesystemOperator) {
+                $filesystem->deleteDirectory('google');
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function it_blocks_promotion_and_keeps_the_live_file_when_a_guardrail_trips(): void
+    {
+        // the single generated item cannot satisfy a min_items guardrail of 100
+        $feedId = (int) $this->persistFixtures([
+            'guardrails' => [
+                ['type' => 'min_items', 'params' => ['min' => 100], 'severity' => 'block'],
+            ],
+        ])->getId();
+
+        // seed a previously published canonical file so we can prove it is kept live
+        $canonical = self::getContainer()->get('setono_sylius_feed.storage.feed');
+        self::assertInstanceOf(FilesystemOperator::class, $canonical);
+        $canonical->write('google/' . self::CONTEXT . '.xml', self::LIVE_CONTENT);
+
+        $commandBus = self::getContainer()->get('setono_sylius_feed.command_bus');
+        self::assertInstanceOf(MessageBusInterface::class, $commandBus);
+        $commandBus->dispatch(new ProcessFeed($feedId));
+
+        $this->entityManager()->clear();
+
+        $repository = self::getContainer()->get('setono_sylius_feed.repository.feed');
+        self::assertInstanceOf(RepositoryInterface::class, $repository);
+        $feed = $repository->find($feedId);
+        self::assertInstanceOf(FeedInterface::class, $feed);
+        self::assertSame(FeedGraph::STATE_COMPLETED, $feed->getState());
+
+        // the candidate was gated: recorded as blocked with a reason
+        $resultRepository = self::getContainer()->get('setono_sylius_feed.repository.feed_context_result');
+        self::assertInstanceOf(FeedContextResultRepositoryInterface::class, $resultRepository);
+        $result = $resultRepository->findLatestForContext($feed, self::CONTEXT);
+        self::assertNotNull($result);
+        self::assertTrue($result->isBlocked());
+        self::assertNotNull($result->getPublishCheck());
+
+        // the live canonical file was NOT overwritten
+        self::assertSame(self::LIVE_CONTENT, $canonical->read('google/' . self::CONTEXT . '.xml'));
+
+        // the blocked candidate is retained in staging for inspection
+        $temporary = self::getContainer()->get('setono_sylius_feed.storage.feed_tmp');
+        self::assertInstanceOf(FilesystemOperator::class, $temporary);
+        self::assertTrue($temporary->fileExists('google/' . self::CONTEXT . '.xml'));
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $manager = self::getContainer()->get('doctrine.orm.entity_manager');
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+
+        return $manager;
+    }
+
+    /**
+     * @param array<string, mixed> $publishConfig
+     */
+    private function persistFixtures(array $publishConfig): FeedInterface
+    {
+        $currency = new Currency();
+        $currency->setCode('USD');
+
+        $locale = new Locale();
+        $locale->setCode('en_US');
+
+        $channel = new Channel();
+        $channel->setCode('web');
+        $channel->setName('Web');
+        $channel->setHostname('localhost');
+        $channel->setBaseCurrency($currency);
+        $channel->setDefaultLocale($locale);
+        $channel->addCurrency($currency);
+        $channel->addLocale($locale);
+        $channel->setTaxCalculationStrategy('order_items_based');
+        $channel->setEnabled(true);
+
+        $product = new Product();
+        $product->setCode('PROD-1');
+        $product->setEnabled(true);
+        $product->setCurrentLocale('en_US');
+        $product->setFallbackLocale('en_US');
+        $product->setName('Acme Shoe');
+        $product->setSlug('acme-shoe');
+        $product->setDescription('A very nice shoe');
+        $product->addChannel($channel);
+
+        $image = new ProductImage();
+        $image->setPath('acme.jpg');
+        $product->addImage($image);
+
+        $variant = new ProductVariant();
+        $variant->setCode('VARIANT-1');
+
+        $channelPricing = new ChannelPricing();
+        $channelPricing->setChannelCode('web');
+        $channelPricing->setPrice(999);
+        $variant->addChannelPricing($channelPricing);
+
+        $product->addVariant($variant);
+
+        $feed = new Feed();
+        $feed->setCode('google');
+        $feed->setFormat('google_rss');
+        $feed->setEnabled(true);
+        $feed->setCurrentLocale('en_US');
+        $feed->setName('Google feed');
+        $feed->setSlug('google-feed');
+        $feed->addChannel($channel);
+        $feed->setPublishConfig($publishConfig);
+
+        $source = new FeedSource();
+        $source->setFeedType('product_variant');
+        $source->setPosition(0);
+        $feed->addSource($source);
+
+        $manager = $this->entityManager();
+        foreach ([$currency, $locale, $channel, $product, $variant, $feed] as $entity) {
+            $manager->persist($entity);
+        }
+        $manager->flush();
+
+        return $feed;
+    }
+}

--- a/tests/Unit/Audit/FeedAuditServiceTest.php
+++ b/tests/Unit/Audit/FeedAuditServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Audit;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Audit\FeedAuditService;
+use Setono\SyliusFeedPlugin\Preview\PreviewFunnel;
+use Setono\SyliusFeedPlugin\Preview\PreviewResult;
+
+/**
+ * The audit is purely advisory: over a known set of included output bags it computes per-field fill
+ * rates, flags soft quality warnings (a > 150-char title, a zero price), and counts value
+ * distributions (availability) — without excluding anything.
+ */
+final class FeedAuditServiceTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_computes_fill_rates_soft_warnings_and_distributions(): void
+    {
+        $longTitle = str_repeat('a', 151);
+
+        $result = new PreviewResult(
+            new PreviewFunnel(3, 3, 3, 3, 3),
+            [
+                ['g:id' => 'SKU-1', 'g:title' => $longTitle, 'g:gtin' => '123', 'g:availability' => 'in_stock', 'g:price' => '9.99 USD'],
+                ['g:id' => 'SKU-2', 'g:title' => 'Short', 'g:availability' => 'in_stock', 'g:price' => '0.00 USD'],
+                ['g:id' => 'SKU-3', 'g:title' => 'Also short', 'g:gtin' => '', 'g:availability' => 'out_of_stock', 'g:price' => '5.00 USD'],
+            ],
+            [],
+        );
+
+        $report = (new FeedAuditService())->audit($result);
+
+        // fill rates: g:id is present and non-empty in all 3 items; g:gtin only in 1 of 3
+        self::assertSame(1.0, $report->fillRates['g:id']);
+        self::assertEqualsWithDelta(1 / 3, $report->fillRates['g:gtin'], 0.0001);
+
+        // soft warnings: exactly one over-long title and exactly one zero price
+        self::assertContains(['type' => 'title_too_long', 'field' => 'g:title', 'count' => 1], $report->warnings);
+        self::assertContains(['type' => 'price_empty', 'field' => 'g:price', 'count' => 1], $report->warnings);
+
+        // distribution: availability value counts
+        self::assertSame(['in_stock' => 2, 'out_of_stock' => 1], $report->distributions['g:availability']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_empty_reports_when_nothing_is_included(): void
+    {
+        $result = new PreviewResult(new PreviewFunnel(0, 0, 0, 0, 0), [], []);
+
+        $report = (new FeedAuditService())->audit($result);
+
+        self::assertSame([], $report->fillRates);
+        self::assertSame([], $report->warnings);
+        self::assertSame([], $report->distributions);
+    }
+}

--- a/tests/Unit/Command/ProcessFeedCommandTest.php
+++ b/tests/Unit/Command/ProcessFeedCommandTest.php
@@ -7,9 +7,16 @@ namespace Setono\SyliusFeedPlugin\Tests\Unit\Command;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Audit\AuditReport;
+use Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface;
 use Setono\SyliusFeedPlugin\Command\ProcessFeedCommand;
+use Setono\SyliusFeedPlugin\Context\ContextFactoryInterface;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\Message\Command\ProcessFeed;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Preview\PreviewFunnel;
+use Setono\SyliusFeedPlugin\Preview\PreviewResult;
+use Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -42,7 +49,7 @@ final class ProcessFeedCommandTest extends TestCase
         $commandBus = $this->prophesize(MessageBusInterface::class);
         $commandBus->dispatch(Argument::type(ProcessFeed::class))->willReturn(new Envelope(new \stdClass()))->shouldBeCalledOnce();
 
-        $tester = new CommandTester(new ProcessFeedCommand($repository->reveal(), $commandBus->reveal()));
+        $tester = new CommandTester($this->command($repository->reveal(), $commandBus->reveal()));
         $exitCode = $tester->execute([]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
@@ -62,7 +69,7 @@ final class ProcessFeedCommandTest extends TestCase
         $commandBus = $this->prophesize(MessageBusInterface::class);
         $commandBus->dispatch(Argument::type(ProcessFeed::class))->willReturn(new Envelope(new \stdClass()))->shouldBeCalledOnce();
 
-        $tester = new CommandTester(new ProcessFeedCommand($repository->reveal(), $commandBus->reveal()));
+        $tester = new CommandTester($this->command($repository->reveal(), $commandBus->reveal()));
 
         self::assertSame(Command::SUCCESS, $tester->execute(['--feed' => 'google']));
     }
@@ -78,7 +85,7 @@ final class ProcessFeedCommandTest extends TestCase
         $commandBus = $this->prophesize(MessageBusInterface::class);
         $commandBus->dispatch(Argument::cetera())->shouldNotBeCalled();
 
-        $tester = new CommandTester(new ProcessFeedCommand($repository->reveal(), $commandBus->reveal()));
+        $tester = new CommandTester($this->command($repository->reveal(), $commandBus->reveal()));
         $exitCode = $tester->execute([]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
@@ -96,8 +103,107 @@ final class ProcessFeedCommandTest extends TestCase
         $commandBus = $this->prophesize(MessageBusInterface::class);
         $commandBus->dispatch(Argument::cetera())->shouldNotBeCalled();
 
-        $tester = new CommandTester(new ProcessFeedCommand($repository->reveal(), $commandBus->reveal()));
+        $tester = new CommandTester($this->command($repository->reveal(), $commandBus->reveal()));
 
         self::assertSame(Command::SUCCESS, $tester->execute([]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_previews_the_funnel_instead_of_generating_when_preview_is_passed(): void
+    {
+        $feed = $this->feed();
+        $context = new FeedContext(null, 'en_US', 'USD');
+
+        $repository = $this->prophesize(RepositoryInterface::class);
+        $repository->findBy(['enabled' => true])->willReturn([$feed]);
+
+        $commandBus = $this->prophesize(MessageBusInterface::class);
+        $commandBus->dispatch(Argument::cetera())->shouldNotBeCalled();
+
+        $contextFactory = $this->prophesize(ContextFactoryInterface::class);
+        $contextFactory->create($feed)->willReturn([$context]);
+
+        $preview = new PreviewResult(
+            new PreviewFunnel(3, 2, 1, 1, 1),
+            [['id' => 'SKU-1']],
+            [['item' => 'SKU-2', 'reason' => 'filter:pre:availability']],
+        );
+        $previewService = $this->prophesize(PreviewServiceInterface::class);
+        $previewService->preview($feed, $context, 3)->willReturn($preview)->shouldBeCalledOnce();
+
+        $auditService = $this->prophesize(FeedAuditServiceInterface::class);
+        $auditService->audit(Argument::cetera())->shouldNotBeCalled();
+
+        $tester = new CommandTester($this->command(
+            $repository->reveal(),
+            $commandBus->reveal(),
+            $contextFactory->reveal(),
+            $previewService->reveal(),
+            $auditService->reveal(),
+        ));
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--preview' => '3']));
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('SKU-1', $display);
+        self::assertStringContainsString('filter:pre:availability', $display);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prints_the_audit_when_audit_is_passed(): void
+    {
+        $feed = $this->feed();
+        $context = new FeedContext(null, 'en_US', 'USD');
+
+        $repository = $this->prophesize(RepositoryInterface::class);
+        $repository->findBy(['enabled' => true])->willReturn([$feed]);
+
+        $commandBus = $this->prophesize(MessageBusInterface::class);
+        $commandBus->dispatch(Argument::cetera())->shouldNotBeCalled();
+
+        $contextFactory = $this->prophesize(ContextFactoryInterface::class);
+        $contextFactory->create($feed)->willReturn([$context]);
+
+        $preview = new PreviewResult(new PreviewFunnel(1, 1, 1, 1, 1), [['g:title' => 'x']], []);
+        $previewService = $this->prophesize(PreviewServiceInterface::class);
+        $previewService->preview($feed, $context, 50)->willReturn($preview);
+
+        $audit = new AuditReport(['g:title' => 1.0], [['type' => 'title_too_long', 'field' => 'g:title', 'count' => 1]], []);
+        $auditService = $this->prophesize(FeedAuditServiceInterface::class);
+        $auditService->audit($preview)->willReturn($audit)->shouldBeCalledOnce();
+
+        $tester = new CommandTester($this->command(
+            $repository->reveal(),
+            $commandBus->reveal(),
+            $contextFactory->reveal(),
+            $previewService->reveal(),
+            $auditService->reveal(),
+        ));
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--audit' => true]));
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('title_too_long', $display);
+        self::assertStringContainsString('100.0%', $display);
+    }
+
+    private function command(
+        RepositoryInterface $repository,
+        MessageBusInterface $commandBus,
+        ?ContextFactoryInterface $contextFactory = null,
+        ?PreviewServiceInterface $previewService = null,
+        ?FeedAuditServiceInterface $auditService = null,
+    ): ProcessFeedCommand {
+        return new ProcessFeedCommand(
+            $repository,
+            $commandBus,
+            $contextFactory ?? $this->prophesize(ContextFactoryInterface::class)->reveal(),
+            $previewService ?? $this->prophesize(PreviewServiceInterface::class)->reveal(),
+            $auditService ?? $this->prophesize(FeedAuditServiceInterface::class)->reveal(),
+        );
     }
 }

--- a/tests/Unit/Controller/Admin/PreviewFeedActionTest.php
+++ b/tests/Unit/Controller/Admin/PreviewFeedActionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Controller\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Audit\AuditReport;
+use Setono\SyliusFeedPlugin\Audit\FeedAuditServiceInterface;
+use Setono\SyliusFeedPlugin\Context\ContextFactoryInterface;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Controller\Admin\PreviewFeedAction;
+use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Preview\PreviewFunnel;
+use Setono\SyliusFeedPlugin\Preview\PreviewResult;
+use Setono\SyliusFeedPlugin\Preview\PreviewServiceInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+
+final class PreviewFeedActionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_renders_the_preview_and_audit(): void
+    {
+        $feed = new Feed();
+        $feed->setCode('google');
+
+        $repository = $this->prophesize(FeedRepositoryInterface::class);
+        $repository->find(1)->willReturn($feed);
+
+        $context = new FeedContext(null, 'en_US', 'USD');
+        $contextFactory = $this->prophesize(ContextFactoryInterface::class);
+        $contextFactory->create($feed)->willReturn([$context]);
+
+        $preview = new PreviewResult(
+            new PreviewFunnel(2, 2, 1, 1, 1),
+            [['id' => 'SKU-1', 'title' => 'Shoe']],
+            [['item' => null, 'reason' => 'validation:missing']],
+        );
+        $previewService = $this->prophesize(PreviewServiceInterface::class);
+        $previewService->preview($feed, $context)->willReturn($preview);
+
+        $audit = new AuditReport(['id' => 1.0], [], []);
+        $auditService = $this->prophesize(FeedAuditServiceInterface::class);
+        $auditService->audit($preview)->willReturn($audit);
+
+        $twig = $this->prophesize(Environment::class);
+        $twig->render(
+            '@SetonoSyliusFeedPlugin/admin/feed/preview.html.twig',
+            Argument::that(static fn (array $context): bool => $context['feed'] === $feed &&
+                $context['preview'] === $preview &&
+                $context['audit'] === $audit &&
+                ['id', 'title'] === $context['columns']),
+        )->willReturn('<html>preview</html>');
+
+        $response = (new PreviewFeedAction(
+            $repository->reveal(),
+            $contextFactory->reveal(),
+            $previewService->reveal(),
+            $auditService->reveal(),
+            $twig->reveal(),
+        ))(1);
+
+        self::assertSame('<html>preview</html>', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function it_404s_for_a_missing_feed(): void
+    {
+        $repository = $this->prophesize(FeedRepositoryInterface::class);
+        $repository->find(999)->willReturn(null);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        (new PreviewFeedAction(
+            $repository->reveal(),
+            $this->prophesize(ContextFactoryInterface::class)->reveal(),
+            $this->prophesize(PreviewServiceInterface::class)->reveal(),
+            $this->prophesize(FeedAuditServiceInterface::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
+        ))(999);
+    }
+}

--- a/tests/Unit/Controller/Admin/PublishContextAnywayActionTest.php
+++ b/tests/Unit/Controller/Admin/PublishContextAnywayActionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Controller\Admin;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\DirectoryAttributes;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Controller\Admin\PublishContextAnywayAction;
+use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+final class PublishContextAnywayActionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_promotes_the_retained_candidate_and_marks_it_published(): void
+    {
+        $stream = fopen('php://temp', 'r');
+        self::assertIsResource($stream);
+
+        $feed = new Feed();
+        $feed->setCode('google');
+
+        $repository = $this->prophesize(FeedRepositoryInterface::class);
+        $repository->find(1)->willReturn($feed);
+
+        $listing = (static function (): \Generator {
+            yield new DirectoryAttributes('google/nested'); // not a file -> skipped
+            yield new FileAttributes('google/web_en_us_usd.xml'); // matches the requested context
+            yield new FileAttributes('google/web_da_dk_dkk.xml'); // a different context -> untouched
+        })();
+
+        $temporary = $this->prophesize(FilesystemOperator::class);
+        $temporary->listContents('google', true)->willReturn(new DirectoryListing($listing));
+        $temporary->readStream('google/web_en_us_usd.xml')->willReturn($stream);
+        $temporary->delete('google/web_en_us_usd.xml')->shouldBeCalledOnce();
+        $temporary->delete('google/web_da_dk_dkk.xml')->shouldNotBeCalled();
+
+        $canonical = $this->prophesize(FilesystemOperator::class);
+        $canonical->writeStream('google/web_en_us_usd.xml', $stream)->shouldBeCalledOnce();
+        $canonical->writeStream('google/web_da_dk_dkk.xml', Argument::any())->shouldNotBeCalled();
+
+        $result = new FeedContextResult();
+        $result->setPublishState(FeedContextResultInterface::PUBLISH_STATE_BLOCKED);
+
+        $resultRepository = $this->prophesize(FeedContextResultRepositoryInterface::class);
+        $resultRepository->findLatestForContext($feed, 'web_en_us_usd')->willReturn($result);
+
+        $manager = $this->prophesize(EntityManagerInterface::class);
+        $manager->flush()->shouldBeCalledOnce();
+
+        $managerRegistry = $this->prophesize(ManagerRegistry::class);
+        $managerRegistry->getManagerForClass(FeedContextResult::class)->willReturn($manager->reveal());
+
+        $router = $this->prophesize(RouterInterface::class);
+        $router->generate('setono_sylius_feed_admin_feed_results', Argument::any())->willReturn('/admin/feeds/1/results');
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+
+        $action = new PublishContextAnywayAction(
+            $managerRegistry->reveal(),
+            $repository->reveal(),
+            $resultRepository->reveal(),
+            $temporary->reveal(),
+            $canonical->reveal(),
+            $router->reveal(),
+        );
+
+        $response = $action($request, 1, 'web_en_us_usd');
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/admin/feeds/1/results', $response->getTargetUrl());
+        self::assertTrue($result->isPublished());
+
+        /** @var array<string, list<string>> $flashes */
+        $flashes = $session->getFlashBag()->peekAll();
+        self::assertContains('setono_sylius_feed.feed.context_published', $flashes['success'] ?? []);
+
+        fclose($stream);
+    }
+
+    /**
+     * @test
+     */
+    public function it_404s_for_a_missing_feed(): void
+    {
+        $repository = $this->prophesize(FeedRepositoryInterface::class);
+        $repository->find(999)->willReturn(null);
+
+        $temporary = $this->prophesize(FilesystemOperator::class);
+        $temporary->listContents(Argument::cetera())->shouldNotBeCalled();
+
+        $action = new PublishContextAnywayAction(
+            $this->prophesize(ManagerRegistry::class)->reveal(),
+            $repository->reveal(),
+            $this->prophesize(FeedContextResultRepositoryInterface::class)->reveal(),
+            $temporary->reveal(),
+            $this->prophesize(FilesystemOperator::class)->reveal(),
+            $this->prophesize(RouterInterface::class)->reveal(),
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $action(new Request(), 999, 'web_en_us_usd');
+    }
+}

--- a/tests/Unit/EventSubscriber/MoveGeneratedFeedSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/MoveGeneratedFeedSubscriberTest.php
@@ -13,6 +13,9 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusFeedPlugin\EventSubscriber\MoveGeneratedFeedSubscriber;
 use Setono\SyliusFeedPlugin\Model\Feed;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
+use Setono\SyliusFeedPlugin\Repository\FeedContextResultRepositoryInterface;
 use Symfony\Component\Workflow\Event\CompletedEvent;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
@@ -36,33 +39,50 @@ final class MoveGeneratedFeedSubscriberTest extends TestCase
     /**
      * @test
      */
-    public function it_swaps_temporary_files_to_canonical_storage_and_stamps_the_feed(): void
+    public function it_promotes_published_contexts_and_retains_blocked_ones(): void
     {
-        $stream = fopen('php://temp', 'r');
-        self::assertIsResource($stream);
+        $publishedStream = fopen('php://temp', 'r');
+        self::assertIsResource($publishedStream);
+        $ungatedStream = fopen('php://temp', 'r');
+        self::assertIsResource($ungatedStream);
 
         $listing = (static function (): \Generator {
             yield new DirectoryAttributes('google/nested'); // not a file -> skipped
-            yield new FileAttributes('google/web_en_us_usd.xml');
+            yield new FileAttributes('google/web_en_us_usd.xml'); // published -> promoted
+            yield new FileAttributes('google/web_da_dk_dkk.xml'); // blocked -> retained
+            yield new FileAttributes('google/web_sv_se_sek.xml'); // no result -> promoted (no gate)
         })();
 
         $temporary = $this->prophesize(FilesystemOperator::class);
         $temporary->listContents('google', true)->willReturn(new DirectoryListing($listing));
-        $temporary->readStream('google/web_en_us_usd.xml')->willReturn($stream);
-        $temporary->deleteDirectory('google')->shouldBeCalled();
+        $temporary->readStream('google/web_en_us_usd.xml')->willReturn($publishedStream);
+        $temporary->readStream('google/web_sv_se_sek.xml')->willReturn($ungatedStream);
+        $temporary->readStream('google/web_da_dk_dkk.xml')->shouldNotBeCalled();
+        $temporary->delete('google/web_en_us_usd.xml')->shouldBeCalledOnce();
+        $temporary->delete('google/web_sv_se_sek.xml')->shouldBeCalledOnce();
+        $temporary->delete('google/web_da_dk_dkk.xml')->shouldNotBeCalled();
 
         $canonical = $this->prophesize(FilesystemOperator::class);
-        $canonical->deleteDirectory('google')->shouldBeCalled();
-        $canonical->writeStream('google/web_en_us_usd.xml', $stream)->shouldBeCalled();
+        $canonical->writeStream('google/web_en_us_usd.xml', $publishedStream)->shouldBeCalledOnce();
+        $canonical->writeStream('google/web_sv_se_sek.xml', $ungatedStream)->shouldBeCalledOnce();
+        $canonical->writeStream('google/web_da_dk_dkk.xml', Argument::any())->shouldNotBeCalled();
+        $canonical->deleteDirectory(Argument::any())->shouldNotBeCalled();
 
         $feed = new Feed();
         $feed->setCode('google');
 
-        (new MoveGeneratedFeedSubscriber($temporary->reveal(), $canonical->reveal()))->onCompleted($this->event($feed));
+        $repository = $this->prophesize(FeedContextResultRepositoryInterface::class);
+        $repository->findLatestForContext($feed, 'web_en_us_usd')->willReturn($this->result(FeedContextResultInterface::PUBLISH_STATE_PUBLISHED));
+        $repository->findLatestForContext($feed, 'web_da_dk_dkk')->willReturn($this->result(FeedContextResultInterface::PUBLISH_STATE_BLOCKED));
+        $repository->findLatestForContext($feed, 'web_sv_se_sek')->willReturn(null);
+
+        (new MoveGeneratedFeedSubscriber($temporary->reveal(), $canonical->reveal(), $repository->reveal()))
+            ->onCompleted($this->event($feed));
 
         self::assertNotNull($feed->getLastGeneratedAt());
 
-        fclose($stream);
+        fclose($publishedStream);
+        fclose($ungatedStream);
     }
 
     /**
@@ -71,12 +91,23 @@ final class MoveGeneratedFeedSubscriberTest extends TestCase
     public function it_ignores_a_non_feed_subject(): void
     {
         $temporary = $this->prophesize(FilesystemOperator::class);
-        $temporary->deleteDirectory(Argument::any())->shouldNotBeCalled();
+        $temporary->listContents(Argument::cetera())->shouldNotBeCalled();
 
-        (new MoveGeneratedFeedSubscriber($temporary->reveal(), $this->prophesize(FilesystemOperator::class)->reveal()))
-            ->onCompleted($this->event(new \stdClass()));
+        (new MoveGeneratedFeedSubscriber(
+            $temporary->reveal(),
+            $this->prophesize(FilesystemOperator::class)->reveal(),
+            $this->prophesize(FeedContextResultRepositoryInterface::class)->reveal(),
+        ))->onCompleted($this->event(new \stdClass()));
 
         self::addToAssertionCount(1);
+    }
+
+    private function result(string $publishState): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setPublishState($publishState);
+
+        return $result;
     }
 
     private function event(object $subject): CompletedEvent

--- a/tests/Unit/Filter/FilterEvaluatorTest.php
+++ b/tests/Unit/Filter/FilterEvaluatorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Filter\FilterEvaluator;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Model\FeedFilter;
+use Setono\SyliusFeedPlugin\Model\FeedFilterInterface;
+use Setono\SyliusFeedPlugin\Operator\Equals;
+use Setono\SyliusFeedPlugin\Operator\GreaterThan;
+use Setono\SyliusFeedPlugin\Operator\In;
+use Setono\SyliusFeedPlugin\Operator\OperatorRegistry;
+use Setono\SyliusFeedPlugin\Reference\ReferenceResolver;
+
+/**
+ * Include/exclude evaluation over the shared operator vocabulary and the reference-resolution rule
+ * (§11): action semantics, first-excluding-wins, and inert (incomplete) filters.
+ */
+final class FilterEvaluatorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_excludes_an_item_when_an_exclude_filter_matches(): void
+    {
+        $item = $this->item(['availability' => 'out_of_stock']);
+        $filter = $this->filter('availability', 'equals', "'out_of_stock'", FeedFilterInterface::ACTION_EXCLUDE);
+
+        self::assertSame($filter, $this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_an_item_when_an_exclude_filter_does_not_match(): void
+    {
+        $item = $this->item(['availability' => 'in_stock']);
+        $filter = $this->filter('availability', 'equals', "'out_of_stock'", FeedFilterInterface::ACTION_EXCLUDE);
+
+        self::assertNull($this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_an_item_when_an_include_filter_does_not_match(): void
+    {
+        $item = $this->item(['availability' => 'out_of_stock']);
+        $filter = $this->filter('availability', 'equals', "'in_stock'", FeedFilterInterface::ACTION_INCLUDE);
+
+        self::assertSame($filter, $this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_an_item_when_an_include_filter_matches(): void
+    {
+        $item = $this->item(['availability' => 'in_stock']);
+        $filter = $this->filter('availability', 'equals', "'in_stock'", FeedFilterInterface::ACTION_INCLUDE);
+
+        self::assertNull($this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_first_excluding_filter(): void
+    {
+        $item = $this->item(['availability' => 'out_of_stock', 'brand' => 'Acme']);
+        $passing = $this->filter('brand', 'equals', "'Acme'", FeedFilterInterface::ACTION_INCLUDE);
+        $excluding = $this->filter('availability', 'equals', "'out_of_stock'", FeedFilterInterface::ACTION_EXCLUDE);
+
+        self::assertSame($excluding, $this->evaluator()->excludedBy($item, [$passing, $excluding]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_a_filter_with_a_null_operator(): void
+    {
+        $item = $this->item(['availability' => 'out_of_stock']);
+
+        $filter = new FeedFilter();
+        $filter->setField('availability');
+        $filter->setOperator(null);
+        $filter->setValue("'out_of_stock'");
+        $filter->setAction(FeedFilterInterface::ACTION_EXCLUDE);
+
+        self::assertNull($this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    /**
+     * A non-string filter value is compared verbatim rather than resolved as a reference.
+     *
+     * @test
+     */
+    public function it_uses_a_non_string_value_verbatim(): void
+    {
+        $item = $this->item(['price' => 100]);
+
+        $filter = new FeedFilter();
+        $filter->setField('price');
+        $filter->setOperator('gt');
+        $filter->setValue(50);
+        $filter->setAction(FeedFilterInterface::ACTION_EXCLUDE);
+
+        self::assertSame($filter, $this->evaluator()->excludedBy($item, [$filter]));
+    }
+
+    private function evaluator(): FilterEvaluator
+    {
+        return new FilterEvaluator(
+            new ReferenceResolver(),
+            new OperatorRegistry([new Equals(), new In(), new GreaterThan()]),
+        );
+    }
+
+    private function filter(string $field, string $operator, mixed $value, string $action): FeedFilterInterface
+    {
+        $filter = new FeedFilter();
+        $filter->setField($field);
+        $filter->setOperator($operator);
+        $filter->setValue($value);
+        $filter->setAction($action);
+
+        return $filter;
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     */
+    private function item(array $source): FeedItem
+    {
+        $item = new FeedItem(new \stdClass(), new FeedContext());
+        $item->setSourceResolver(static fn (string $field): mixed => $source[$field] ?? null);
+
+        return $item;
+    }
+}

--- a/tests/Unit/Generator/FeedGeneratorFilterTest.php
+++ b/tests/Unit/Generator/FeedGeneratorFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusFeedPlugin\Tests\Unit\Generator;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use League\Csv\Reader;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use PHPUnit\Framework\TestCase;
@@ -15,81 +16,99 @@ use Setono\SyliusFeedPlugin\FeedType\FeedTypeInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
 use Setono\SyliusFeedPlugin\Filter\FilterEvaluator;
 use Setono\SyliusFeedPlugin\Filter\FilterSet;
+use Setono\SyliusFeedPlugin\Format\CsvFormat;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
-use Setono\SyliusFeedPlugin\Format\GoogleRssFormat;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
-use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
+use Setono\SyliusFeedPlugin\Model\FeedField;
+use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
+use Setono\SyliusFeedPlugin\Model\FeedFilter;
+use Setono\SyliusFeedPlugin\Model\FeedFilterInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+use Setono\SyliusFeedPlugin\Operator\Equals;
 use Setono\SyliusFeedPlugin\Operator\IsTrue;
 use Setono\SyliusFeedPlugin\Operator\OperatorRegistry;
 use Setono\SyliusFeedPlugin\Reference\ReferenceResolver;
 use Setono\SyliusFeedPlugin\Scripting\ExpressionEvaluator;
 use Setono\SyliusFeedPlugin\Scripting\FeedTemplateSecurityPolicy;
 use Setono\SyliusFeedPlugin\Scripting\SandboxedTwigRenderer;
-use Setono\SyliusFeedPlugin\Transformation\MoneyFormat;
-use Setono\SyliusFeedPlugin\Transformation\StripTags;
 use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
-use Setono\SyliusFeedPlugin\Transformation\Truncate;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
+use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
+use Setono\SyliusFeedPlugin\Writer\CsvWriter;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
-use Setono\SyliusFeedPlugin\Writer\XmlWriter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 
 /**
- * Performance budget (§6.3, M1 acceptance): a 50,000-item feed must stream to storage without
- * accumulating the result set in memory. Asserts that peak memory growth during generation stays
- * far below the 256 MB budget — proving the writer/generator stream rather than buffer.
+ * The §11 acceptance for the FilterEvaluator wired into the generator: a source with an
+ * exclude-out-of-stock filter drops the out-of-stock item from the output while keeping the
+ * in-stock one — proving the filter is selective (not just "drops everything"). The same filter is
+ * exercised at both the `pre` and `post` stage.
  */
-final class FeedGeneratorMemoryTest extends TestCase
+final class FeedGeneratorFilterTest extends TestCase
 {
     use ProphecyTrait;
 
-    public const ITEMS = 50000;
+    private Filesystem $filesystem;
 
-    /**
-     * @test
-     */
-    public function it_generates_a_large_feed_within_the_memory_budget(): void
+    protected function setUp(): void
     {
-        $filesystem = new Filesystem(new LocalFilesystemAdapter(sys_get_temp_dir() . '/setono-feed-' . bin2hex(random_bytes(6))));
-
-        $generator = $this->createGenerator($filesystem);
-
-        $before = memory_get_peak_usage(true);
-        $result = $generator->generate($this->feed(), new FeedContext(null, 'en_US', 'USD'));
-        $growth = memory_get_peak_usage(true) - $before;
-
-        self::assertSame(self::ITEMS, $result->itemCount);
-        // Streaming means peak memory does not scale with item count; allow generous headroom but
-        // far under the 256 MB budget.
-        self::assertLessThan(64 * 1024 * 1024, $growth);
-
-        $filesystem->deleteDirectory('google');
+        $this->filesystem = new Filesystem(new LocalFilesystemAdapter(sys_get_temp_dir() . '/setono-feed-' . bin2hex(random_bytes(6))));
     }
 
-    private function createGenerator(Filesystem $filesystem): FeedGenerator
+    protected function tearDown(): void
+    {
+        $this->filesystem->deleteDirectory('shop');
+    }
+
+    /**
+     * @dataProvider stages
+     *
+     * @test
+     */
+    public function it_excludes_the_out_of_stock_item(string $stage): void
+    {
+        $result = $this->createGenerator()->generate($this->feed($stage), new FeedContext(null, 'en_US', 'USD'));
+
+        self::assertSame(1, $result->itemCount);
+        self::assertSame(1, $result->excludedCount);
+
+        $rows = [...Reader::createFromString($this->filesystem->read($result->path))->getRecords()];
+        self::assertCount(2, $rows, 'header + the single kept row');
+        self::assertSame(['id', 'availability'], $rows[0]);
+        self::assertSame(['SKU-1', 'in_stock'], $rows[1]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function stages(): iterable
+    {
+        yield 'pre' => [FeedFilterInterface::STAGE_PRE];
+        yield 'post' => [FeedFilterInterface::STAGE_POST];
+    }
+
+    private function createGenerator(): FeedGenerator
     {
         $feedTypeRegistry = $this->prophesize(FeedTypeRegistryInterface::class);
         $feedTypeRegistry->get('product_variant')->willReturn($this->feedType());
 
         $presetRegistry = $this->prophesize(MappingPresetRegistryInterface::class);
-        $presetRegistry->forFeedType('product_variant')->willReturn([new GoogleShoppingMappingPreset()]);
 
         $formatRegistry = $this->prophesize(FormatRegistryInterface::class);
-        $formatRegistry->get('google_rss')->willReturn(new GoogleRssFormat());
+        $formatRegistry->get('csv')->willReturn(new CsvFormat());
 
         $writerRegistry = $this->prophesize(FeedWriterRegistryInterface::class);
-        $writerRegistry->get('xml')->willReturn(new XmlWriter());
+        $writerRegistry->get('csv')->willReturn(new CsvWriter());
 
         $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->getContext()->willReturn(new RequestContext());
@@ -100,32 +119,27 @@ final class FeedGeneratorMemoryTest extends TestCase
             $formatRegistry->reveal(),
             $writerRegistry->reveal(),
             new FieldMappingEvaluator(
-                new TransformationChain(new TransformationRegistry([new Truncate(), new StripTags(), new MoneyFormat()])),
+                new TransformationChain(new TransformationRegistry([])),
                 new ReferenceResolver(),
                 new OperatorRegistry([new IsTrue()]),
                 new ExpressionEvaluator(new InMemoryLookup()),
                 new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), new InMemoryLookup()),
                 new NullLookupReferenceResolver(),
             ),
-            new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([])),
+            new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([new Equals()])),
             new NullLookupReferenceResolver(),
             new RequiredFieldsValidator(),
             new EventDispatcher(),
             $urlGenerator->reveal(),
-            $filesystem,
+            $this->filesystem,
         );
     }
 
     private function feedType(): FeedTypeInterface
     {
         $fields = [
-            'id' => $this->field('id', FieldType::STRING, 'SKU-1'),
-            'title' => $this->field('title', FieldType::STRING, 'Acme Shoe'),
-            'description' => $this->field('description', FieldType::STRING, 'A nice shoe'),
-            'link' => $this->field('link', FieldType::URL, 'https://example.com/p/1'),
-            'main_image' => $this->field('main_image', FieldType::IMAGE, 'https://example.com/i/1.jpg'),
-            'availability' => $this->field('availability', FieldType::STRING, 'in_stock'),
-            'channel_price' => $this->field('channel_price', FieldType::MONEY, 999),
+            'id' => $this->field('id'),
+            'availability' => $this->field('availability'),
         ];
 
         $dataSource = new class() implements DataSourceInterface {
@@ -136,14 +150,13 @@ final class FeedGeneratorMemoryTest extends TestCase
 
             public function getItems(FeedContext $context, FilterSet $filters): iterable
             {
-                for ($i = 0; $i < FeedGeneratorMemoryTest::ITEMS; ++$i) {
-                    yield new \stdClass();
-                }
+                yield (object) ['id' => 'SKU-1', 'availability' => 'in_stock'];
+                yield (object) ['id' => 'SKU-2', 'availability' => 'out_of_stock'];
             }
 
             public function count(FeedContext $context, FilterSet $filters): int
             {
-                return FeedGeneratorMemoryTest::ITEMS;
+                return 2;
             }
         };
 
@@ -184,24 +197,80 @@ final class FeedGeneratorMemoryTest extends TestCase
         };
     }
 
-    private function field(string $name, FieldType $type, mixed $value): FieldDefinition
+    /**
+     * A field whose resolver reads the same-named property off the entity, so the two stub entities
+     * resolve to different availability values.
+     */
+    private function field(string $name): FieldDefinition
     {
-        return new FieldDefinition($name, 'test.' . $name, $type, new FixedValueResolver($name, $type, $value));
+        $resolver = new class($name) implements ValueResolverInterface {
+            public function __construct(private readonly string $name)
+            {
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getLabel(): string
+            {
+                return 'test.' . $this->name;
+            }
+
+            public function getType(): FieldType
+            {
+                return FieldType::STRING;
+            }
+
+            public function supports(string $resourceClass): bool
+            {
+                return true;
+            }
+
+            public function resolve(object $entity, FeedContext $context): mixed
+            {
+                return ((array) $entity)[$this->name] ?? null;
+            }
+        };
+
+        return new FieldDefinition($name, $resolver->getLabel(), FieldType::STRING, $resolver);
     }
 
-    private function feed(): FeedInterface
+    private function feed(string $stage): FeedInterface
     {
+        $filter = new FeedFilter();
+        $filter->setField('availability');
+        $filter->setOperator('equals');
+        $filter->setValue("'out_of_stock'");
+        $filter->setAction(FeedFilterInterface::ACTION_EXCLUDE);
+        $filter->setStage($stage);
+
         $source = $this->prophesize(FeedSourceInterface::class);
         $source->getFeedType()->willReturn('product_variant');
         $source->getPosition()->willReturn(0);
-        $source->getFilters()->willReturn(new ArrayCollection());
-        $source->getFields()->willReturn(new ArrayCollection());
+        $source->getFilters()->willReturn(new ArrayCollection([$filter]));
+        $source->getFields()->willReturn(new ArrayCollection([
+            $this->feedField('id', 'id', 0),
+            $this->feedField('availability', 'availability', 1),
+        ]));
 
         $feed = $this->prophesize(FeedInterface::class);
-        $feed->getCode()->willReturn('google');
-        $feed->getFormat()->willReturn('google_rss');
+        $feed->getCode()->willReturn('shop');
+        $feed->getFormat()->willReturn('csv');
         $feed->getSources()->willReturn(new ArrayCollection([$source->reveal()]));
 
         return $feed->reveal();
+    }
+
+    private function feedField(string $outputField, string $sourceField, int $position): FeedFieldInterface
+    {
+        $field = new FeedField();
+        $field->setOutputField($outputField);
+        $field->setSourceType('field');
+        $field->setSourceValue($sourceField);
+        $field->setPosition($position);
+
+        return $field;
     }
 }

--- a/tests/Unit/Generator/FeedGeneratorFilterTest.php
+++ b/tests/Unit/Generator/FeedGeneratorFilterTest.php
@@ -20,6 +20,7 @@ use Setono\SyliusFeedPlugin\Format\CsvFormat;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
@@ -40,6 +41,7 @@ use Setono\SyliusFeedPlugin\Scripting\FeedTemplateSecurityPolicy;
 use Setono\SyliusFeedPlugin\Scripting\SandboxedTwigRenderer;
 use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidator;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
 use Setono\SyliusFeedPlugin\Writer\CsvWriter;
@@ -47,6 +49,7 @@ use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Validator\Validation;
 
 /**
  * The §11 acceptance for the FilterEvaluator wired into the generator: a source with an
@@ -81,6 +84,13 @@ final class FeedGeneratorFilterTest extends TestCase
 
         self::assertSame(1, $result->itemCount);
         self::assertSame(1, $result->excludedCount);
+
+        // the exclusion is recorded with the stage-qualified filter reason (§11); the item id is
+        // only resolvable once mapping has run, so it is present for a `post` filter but null for `pre`
+        self::assertCount(1, $result->errors);
+        self::assertSame(sprintf('filter:%s:availability', $stage), $result->errors[0]['reason']);
+        self::assertSame(FeedFilterInterface::STAGE_POST === $stage ? 'SKU-2' : null, $result->errors[0]['item']);
+        self::assertGreaterThan(0, $result->bytes, 'the produced file has a non-zero byte size');
 
         $rows = [...Reader::createFromString($this->filesystem->read($result->path))->getRecords()];
         self::assertCount(2, $rows, 'header + the single kept row');
@@ -128,7 +138,7 @@ final class FeedGeneratorFilterTest extends TestCase
             ),
             new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([new Equals()])),
             new NullLookupReferenceResolver(),
-            new RequiredFieldsValidator(),
+            new FeedItemValidator(Validation::createValidator(), new RequiredFieldsValidator()),
             new EventDispatcher(),
             $urlGenerator->reveal(),
             $this->filesystem,
@@ -183,6 +193,11 @@ final class FeedGeneratorFilterTest extends TestCase
             public function getDataSource(): DataSourceInterface
             {
                 return $this->dataSource;
+            }
+
+            public function createItem(object $entity, FeedContext $context): FeedItem
+            {
+                return new FeedItem($entity, $context);
             }
 
             public function getScopeDimensions(): array

--- a/tests/Unit/Generator/FeedGeneratorMemoryTest.php
+++ b/tests/Unit/Generator/FeedGeneratorMemoryTest.php
@@ -19,6 +19,7 @@ use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
 use Setono\SyliusFeedPlugin\Format\GoogleRssFormat;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
@@ -38,12 +39,14 @@ use Setono\SyliusFeedPlugin\Transformation\StripTags;
 use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
 use Setono\SyliusFeedPlugin\Transformation\Truncate;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidator;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
 use Setono\SyliusFeedPlugin\Writer\XmlWriter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Validator\Validation;
 
 /**
  * Performance budget (§6.3, M1 acceptance): a 50,000-item feed must stream to storage without
@@ -109,7 +112,7 @@ final class FeedGeneratorMemoryTest extends TestCase
             ),
             new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([])),
             new NullLookupReferenceResolver(),
-            new RequiredFieldsValidator(),
+            new FeedItemValidator(Validation::createValidator(), new RequiredFieldsValidator()),
             new EventDispatcher(),
             $urlGenerator->reveal(),
             $filesystem,
@@ -170,6 +173,11 @@ final class FeedGeneratorMemoryTest extends TestCase
             public function getDataSource(): DataSourceInterface
             {
                 return $this->dataSource;
+            }
+
+            public function createItem(object $entity, FeedContext $context): FeedItem
+            {
+                return new FeedItem($entity, $context);
             }
 
             public function getScopeDimensions(): array

--- a/tests/Unit/Generator/FeedGeneratorMemoryTest.php
+++ b/tests/Unit/Generator/FeedGeneratorMemoryTest.php
@@ -23,6 +23,7 @@ use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\Mapping\MappingResolver;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
@@ -99,7 +100,7 @@ final class FeedGeneratorMemoryTest extends TestCase
 
         return new FeedGenerator(
             $feedTypeRegistry->reveal(),
-            $presetRegistry->reveal(),
+            new MappingResolver($presetRegistry->reveal()),
             $formatRegistry->reveal(),
             $writerRegistry->reveal(),
             new FieldMappingEvaluator(

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -26,6 +26,7 @@ use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
+use Setono\SyliusFeedPlugin\Mapping\MappingResolver;
 use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\MappingPreset\GoogleShoppingMappingPreset;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
@@ -259,7 +260,7 @@ final class FeedGeneratorTest extends TestCase
 
         return new FeedGenerator(
             $feedTypeRegistry->reveal(),
-            $presetRegistry->reveal(),
+            new MappingResolver($presetRegistry->reveal()),
             $formatRegistry->reveal(),
             $writerRegistry->reveal(),
             new FieldMappingEvaluator(

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -14,6 +14,7 @@ use Setono\SyliusFeedPlugin\Context\FeedContext;
 use Setono\SyliusFeedPlugin\DataSource\DataSourceInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
+use Setono\SyliusFeedPlugin\Filter\FilterEvaluator;
 use Setono\SyliusFeedPlugin\Filter\FilterSet;
 use Setono\SyliusFeedPlugin\Format\CsvFormat;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
@@ -33,6 +34,7 @@ use Setono\SyliusFeedPlugin\Model\FeedField;
 use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+use Setono\SyliusFeedPlugin\Operator\Equals;
 use Setono\SyliusFeedPlugin\Operator\IsTrue;
 use Setono\SyliusFeedPlugin\Operator\OperatorRegistry;
 use Setono\SyliusFeedPlugin\Reference\ReferenceResolver;
@@ -265,6 +267,8 @@ final class FeedGeneratorTest extends TestCase
                 new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), new InMemoryLookup()),
                 new NullLookupReferenceResolver(),
             ),
+            new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([new Equals()])),
+            new NullLookupReferenceResolver(),
             new RequiredFieldsValidator(),
             new EventDispatcher(),
             $urlGenerator->reveal(),

--- a/tests/Unit/Generator/FeedGeneratorTest.php
+++ b/tests/Unit/Generator/FeedGeneratorTest.php
@@ -22,6 +22,7 @@ use Setono\SyliusFeedPlugin\Format\GoogleRssFormat;
 use Setono\SyliusFeedPlugin\Format\PartnerAdsFormat;
 use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
@@ -47,6 +48,7 @@ use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
 use Setono\SyliusFeedPlugin\Transformation\Truncate;
 use Setono\SyliusFeedPlugin\Transformation\ValueMap;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidator;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
 use Setono\SyliusFeedPlugin\Writer\CsvWriter;
 use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
@@ -55,6 +57,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Validator\Validation;
 
 /**
  * Acceptance test for the M1 engine: generating a Google Shopping feed for a context produces a
@@ -269,7 +272,7 @@ final class FeedGeneratorTest extends TestCase
             ),
             new FilterEvaluator(new ReferenceResolver(), new OperatorRegistry([new Equals()])),
             new NullLookupReferenceResolver(),
-            new RequiredFieldsValidator(),
+            new FeedItemValidator(Validation::createValidator(), new RequiredFieldsValidator()),
             new EventDispatcher(),
             $urlGenerator->reveal(),
             $this->filesystem,
@@ -334,6 +337,11 @@ final class FeedGeneratorTest extends TestCase
             public function getDataSource(): DataSourceInterface
             {
                 return $this->dataSource;
+            }
+
+            public function createItem(object $entity, FeedContext $context): FeedItem
+            {
+                return new FeedItem($entity, $context);
             }
 
             public function getScopeDimensions(): array

--- a/tests/Unit/Mapping/MappingResolverTest.php
+++ b/tests/Unit/Mapping/MappingResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Mapping;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Mapping\FieldMapping;
+use Setono\SyliusFeedPlugin\Mapping\MappingResolver;
+use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetInterface;
+use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
+use Setono\SyliusFeedPlugin\Model\FeedField;
+use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
+
+/**
+ * The admin-editable FeedField rows win once a source has any (ordered by position); otherwise the
+ * matching MappingPreset is the fallback. This is the single resolution shared by the generator and
+ * the preview, so both consume the exact same mappings.
+ */
+final class MappingResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_hydrates_mappings_from_feed_fields_ordered_by_position(): void
+    {
+        $source = $this->prophesize(FeedSourceInterface::class);
+        $source->getFields()->willReturn(new ArrayCollection([
+            $this->feedField('title', 'title', 1),
+            $this->feedField('id', 'id', 0),
+        ]));
+
+        $presetRegistry = $this->prophesize(MappingPresetRegistryInterface::class);
+
+        $mappings = (new MappingResolver($presetRegistry->reveal()))->resolve(
+            $this->prophesize(FeedInterface::class)->reveal(),
+            $source->reveal(),
+        );
+
+        self::assertCount(2, $mappings);
+        self::assertSame('id', $mappings[0]->getOutputField());
+        self::assertSame('title', $mappings[1]->getOutputField());
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_the_matching_preset_when_there_are_no_feed_fields(): void
+    {
+        $source = $this->prophesize(FeedSourceInterface::class);
+        $source->getFields()->willReturn(new ArrayCollection());
+        $source->getFeedType()->willReturn('product_variant');
+
+        $feed = $this->prophesize(FeedInterface::class);
+        $feed->getFormat()->willReturn('google_rss');
+
+        $expected = [FieldMapping::field('g:id', 'id')];
+
+        $nonMatching = $this->prophesize(MappingPresetInterface::class);
+        $nonMatching->getFormat()->willReturn('csv');
+
+        $matching = $this->prophesize(MappingPresetInterface::class);
+        $matching->getFormat()->willReturn('google_rss');
+        $matching->getMapping()->willReturn($expected);
+
+        $presetRegistry = $this->prophesize(MappingPresetRegistryInterface::class);
+        $presetRegistry->forFeedType('product_variant')->willReturn([$nonMatching->reveal(), $matching->reveal()]);
+
+        $mappings = (new MappingResolver($presetRegistry->reveal()))->resolve($feed->reveal(), $source->reveal());
+
+        self::assertSame($expected, $mappings);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_mappings_when_neither_fields_nor_a_matching_preset_exist(): void
+    {
+        $source = $this->prophesize(FeedSourceInterface::class);
+        $source->getFields()->willReturn(new ArrayCollection());
+        $source->getFeedType()->willReturn('product_variant');
+
+        $feed = $this->prophesize(FeedInterface::class);
+        $feed->getFormat()->willReturn('google_rss');
+
+        $presetRegistry = $this->prophesize(MappingPresetRegistryInterface::class);
+        $presetRegistry->forFeedType('product_variant')->willReturn([]);
+
+        $mappings = (new MappingResolver($presetRegistry->reveal()))->resolve($feed->reveal(), $source->reveal());
+
+        self::assertSame([], $mappings);
+    }
+
+    private function feedField(string $outputField, string $sourceField, int $position): FeedFieldInterface
+    {
+        $field = new FeedField();
+        $field->setOutputField($outputField);
+        $field->setSourceType('field');
+        $field->setSourceValue($sourceField);
+        $field->setPosition($position);
+
+        return $field;
+    }
+}

--- a/tests/Unit/Model/FeedContextResultTest.php
+++ b/tests/Unit/Model/FeedContextResultTest.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusFeedPlugin\Tests\Unit\Model;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Model\FeedContextResultInterface;
 use Setono\SyliusFeedPlugin\Model\FeedInterface;
 
 final class FeedContextResultTest extends TestCase
@@ -28,6 +29,8 @@ final class FeedContextResultTest extends TestCase
         $result->setExcludedCount(3);
         $result->setBytes(1024);
         $result->setErrors([['item' => 'SKU-1', 'reason' => 'validation:missing title']]);
+        $result->setPublishState(FeedContextResultInterface::PUBLISH_STATE_BLOCKED);
+        $result->setPublishCheck(['max_drop_pct: guardrail tripped (severity: block)']);
         $result->setCreatedAt($createdAt);
 
         self::assertNull($result->getId());
@@ -37,7 +40,38 @@ final class FeedContextResultTest extends TestCase
         self::assertSame(3, $result->getExcludedCount());
         self::assertSame(1024, $result->getBytes());
         self::assertSame([['item' => 'SKU-1', 'reason' => 'validation:missing title']], $result->getErrors());
+        self::assertSame(FeedContextResultInterface::PUBLISH_STATE_BLOCKED, $result->getPublishState());
+        self::assertSame(['max_drop_pct: guardrail tripped (severity: block)'], $result->getPublishCheck());
         self::assertSame($createdAt, $result->getCreatedAt());
+    }
+
+    /**
+     * @test
+     */
+    public function it_starts_pending_with_no_publish_check(): void
+    {
+        $result = new FeedContextResult();
+
+        self::assertSame(FeedContextResultInterface::PUBLISH_STATE_PENDING, $result->getPublishState());
+        self::assertNull($result->getPublishCheck());
+        self::assertFalse($result->isPublished());
+        self::assertFalse($result->isBlocked());
+    }
+
+    /**
+     * @test
+     */
+    public function it_reflects_its_publish_state_through_predicates(): void
+    {
+        $result = new FeedContextResult();
+
+        $result->setPublishState(FeedContextResultInterface::PUBLISH_STATE_PUBLISHED);
+        self::assertTrue($result->isPublished());
+        self::assertFalse($result->isBlocked());
+
+        $result->setPublishState(FeedContextResultInterface::PUBLISH_STATE_BLOCKED);
+        self::assertFalse($result->isPublished());
+        self::assertTrue($result->isBlocked());
     }
 
     /**

--- a/tests/Unit/Model/FeedContextResultTest.php
+++ b/tests/Unit/Model/FeedContextResultTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Model\FeedInterface;
+
+final class FeedContextResultTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_exposes_its_accessors(): void
+    {
+        $feed = $this->prophesize(FeedInterface::class)->reveal();
+        $createdAt = new \DateTimeImmutable('2026-07-02 10:00:00');
+
+        $result = new FeedContextResult();
+        $result->setFeed($feed);
+        $result->setContextKey('web_en_US_USD');
+        $result->setItemCount(42);
+        $result->setExcludedCount(3);
+        $result->setBytes(1024);
+        $result->setErrors([['item' => 'SKU-1', 'reason' => 'validation:missing title']]);
+        $result->setCreatedAt($createdAt);
+
+        self::assertNull($result->getId());
+        self::assertSame($feed, $result->getFeed());
+        self::assertSame('web_en_US_USD', $result->getContextKey());
+        self::assertSame(42, $result->getItemCount());
+        self::assertSame(3, $result->getExcludedCount());
+        self::assertSame(1024, $result->getBytes());
+        self::assertSame([['item' => 'SKU-1', 'reason' => 'validation:missing title']], $result->getErrors());
+        self::assertSame($createdAt, $result->getCreatedAt());
+    }
+
+    /**
+     * @test
+     */
+    public function it_defaults_created_at_to_now(): void
+    {
+        self::assertEqualsWithDelta(time(), (new FeedContextResult())->getCreatedAt()->getTimestamp(), 5);
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_errors(): void
+    {
+        $result = new FeedContextResult();
+        $result->addError('SKU-1', 'filter:pre:availability');
+        $result->addError(null, 'skipped');
+
+        self::assertSame([
+            ['item' => 'SKU-1', 'reason' => 'filter:pre:availability'],
+            ['item' => null, 'reason' => 'skipped'],
+        ], $result->getErrors());
+    }
+}

--- a/tests/Unit/Model/FeedTest.php
+++ b/tests/Unit/Model/FeedTest.php
@@ -26,6 +26,7 @@ final class FeedTest extends TestCase
         self::assertTrue($feed->isEnabled());
         self::assertSame(FeedGraph::STATE_READY, $feed->getState());
         self::assertSame([], $feed->getFormatConfig());
+        self::assertSame([], $feed->getPublishConfig());
         self::assertNull($feed->getLastGeneratedAt());
         self::assertCount(0, $feed->getChannels());
         self::assertCount(0, $feed->getSources());
@@ -44,6 +45,7 @@ final class FeedTest extends TestCase
         $feed->setFormat('google_rss');
         $feed->setState(FeedGraph::STATE_PROCESSING);
         $feed->setFormatConfig(['gzip' => true]);
+        $feed->setPublishConfig(['guardrails' => [['type' => 'non_empty', 'severity' => 'block']]]);
         $feed->setLastGeneratedAt($generatedAt);
 
         self::assertSame('google', $feed->getCode());
@@ -51,6 +53,7 @@ final class FeedTest extends TestCase
         self::assertSame('google_rss', $feed->getFormat());
         self::assertSame(FeedGraph::STATE_PROCESSING, $feed->getState());
         self::assertSame(['gzip' => true], $feed->getFormatConfig());
+        self::assertSame(['guardrails' => [['type' => 'non_empty', 'severity' => 'block']]], $feed->getPublishConfig());
         self::assertSame($generatedAt, $feed->getLastGeneratedAt());
     }
 

--- a/tests/Unit/Preview/PreviewServiceTest.php
+++ b/tests/Unit/Preview/PreviewServiceTest.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Setono\SyliusFeedPlugin\Tests\Unit\Generator;
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Preview;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use League\Csv\Reader;
-use League\Flysystem\Filesystem;
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusFeedPlugin\Context\FeedContext;
@@ -16,16 +13,14 @@ use Setono\SyliusFeedPlugin\FeedType\FeedTypeInterface;
 use Setono\SyliusFeedPlugin\FeedType\FeedTypeRegistryInterface;
 use Setono\SyliusFeedPlugin\Filter\FilterEvaluator;
 use Setono\SyliusFeedPlugin\Filter\FilterSet;
-use Setono\SyliusFeedPlugin\Format\CsvFormat;
+use Setono\SyliusFeedPlugin\Format\FormatInterface;
 use Setono\SyliusFeedPlugin\Format\FormatRegistryInterface;
-use Setono\SyliusFeedPlugin\Generator\FeedGenerator;
 use Setono\SyliusFeedPlugin\Generator\FieldMappingEvaluator;
 use Setono\SyliusFeedPlugin\Item\FeedItem;
 use Setono\SyliusFeedPlugin\Lookup\InMemoryLookup;
 use Setono\SyliusFeedPlugin\Mapping\FieldDefinition;
 use Setono\SyliusFeedPlugin\Mapping\FieldType;
 use Setono\SyliusFeedPlugin\Mapping\MappingResolver;
-use Setono\SyliusFeedPlugin\Mapping\ScopeDimension;
 use Setono\SyliusFeedPlugin\MappingPreset\MappingPresetRegistryInterface;
 use Setono\SyliusFeedPlugin\Model\FeedField;
 use Setono\SyliusFeedPlugin\Model\FeedFieldInterface;
@@ -36,103 +31,149 @@ use Setono\SyliusFeedPlugin\Model\FeedSourceInterface;
 use Setono\SyliusFeedPlugin\Operator\Equals;
 use Setono\SyliusFeedPlugin\Operator\IsTrue;
 use Setono\SyliusFeedPlugin\Operator\OperatorRegistry;
+use Setono\SyliusFeedPlugin\Preview\PreviewService;
 use Setono\SyliusFeedPlugin\Reference\ReferenceResolver;
 use Setono\SyliusFeedPlugin\Scripting\ExpressionEvaluator;
 use Setono\SyliusFeedPlugin\Scripting\FeedTemplateSecurityPolicy;
 use Setono\SyliusFeedPlugin\Scripting\SandboxedTwigRenderer;
+use Setono\SyliusFeedPlugin\Tests\Unit\Generator\NullLookupReferenceResolver;
 use Setono\SyliusFeedPlugin\Transformation\TransformationChain;
 use Setono\SyliusFeedPlugin\Transformation\TransformationRegistry;
 use Setono\SyliusFeedPlugin\Validator\FeedItemValidator;
 use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
 use Setono\SyliusFeedPlugin\ValueResolver\ValueResolverInterface;
-use Setono\SyliusFeedPlugin\Writer\CsvWriter;
-use Setono\SyliusFeedPlugin\Writer\FeedWriterRegistryInterface;
+use Setono\SyliusFeedPlugin\Writer\CsvWriterConfig;
+use Setono\SyliusFeedPlugin\Writer\WriterConfigInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Validator\Validation;
 
 /**
- * The §11 acceptance for the FilterEvaluator wired into the generator: a source with an
- * exclude-out-of-stock filter drops the out-of-stock item from the output while keeping the
- * in-stock one — proving the filter is selective (not just "drops everything"). The same filter is
- * exercised at both the `pre` and `post` stage.
+ * Runs the preview over a stub feed type + data source (mirroring the generator tests) to prove the
+ * dry-run pipeline reports the same include/exclude decisions the generator makes — the funnel
+ * counts, the mapped output of included items, and the reason each excluded item was dropped —
+ * without writing anything.
  */
-final class FeedGeneratorFilterTest extends TestCase
+final class PreviewServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    private Filesystem $filesystem;
-
-    protected function setUp(): void
-    {
-        $this->filesystem = new Filesystem(new LocalFilesystemAdapter(sys_get_temp_dir() . '/setono-feed-' . bin2hex(random_bytes(6))));
-    }
-
-    protected function tearDown(): void
-    {
-        $this->filesystem->deleteDirectory('shop');
-    }
-
     /**
-     * @dataProvider stages
-     *
      * @test
      */
-    public function it_excludes_the_out_of_stock_item(string $stage): void
+    public function it_reports_the_funnel_and_the_included_sample(): void
     {
-        $result = $this->createGenerator()->generate($this->feed($stage), new FeedContext(null, 'en_US', 'USD'));
+        $service = $this->createPreviewService($this->catalog());
 
-        self::assertSame(1, $result->itemCount);
-        self::assertSame(1, $result->excludedCount);
+        $result = $service->preview($this->feed(), new FeedContext(null, 'en_US', 'USD'));
 
-        // the exclusion is recorded with the stage-qualified filter reason (§11); the item id is
-        // only resolvable once mapping has run, so it is present for a `post` filter but null for `pre`
-        self::assertCount(1, $result->errors);
-        self::assertSame(sprintf('filter:%s:availability', $stage), $result->errors[0]['reason']);
-        self::assertSame(FeedFilterInterface::STAGE_POST === $stage ? 'SKU-2' : null, $result->errors[0]['item']);
-        self::assertGreaterThan(0, $result->bytes, 'the produced file has a non-zero byte size');
+        // three sampled → one dropped by the pre-filter, one dropped by validation (empty id) → one kept
+        self::assertSame(3, $result->funnel->source);
+        self::assertSame(2, $result->funnel->afterPreFilters);
+        self::assertSame(1, $result->funnel->afterMappingValidation);
+        self::assertSame(1, $result->funnel->afterPostFilters);
+        self::assertSame(1, $result->funnel->included);
 
-        $rows = [...Reader::createFromString($this->filesystem->read($result->path))->getRecords()];
-        self::assertCount(2, $rows, 'header + the single kept row');
-        self::assertSame(['id', 'availability'], $rows[0]);
-        self::assertSame(['SKU-1', 'in_stock'], $rows[1]);
+        self::assertCount(1, $result->included);
+        self::assertSame(['id' => 'SKU-1', 'title' => 'Shoe', 'availability' => 'in_stock'], $result->included[0]);
+
+        $reasons = array_column($result->excluded, 'reason');
+        self::assertContains('filter:pre:availability', $reasons);
+        self::assertNotEmpty(array_filter($reasons, static fn (string $reason): bool => str_starts_with($reason, 'validation:')));
     }
 
     /**
-     * @return iterable<string, array{string}>
+     * @test
      */
-    public function stages(): iterable
+    public function it_bounds_the_sample_to_the_limit(): void
     {
-        yield 'pre' => [FeedFilterInterface::STAGE_PRE];
-        yield 'post' => [FeedFilterInterface::STAGE_POST];
+        $entities = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $entities[] = (object) ['id' => 'SKU-' . $i, 'title' => 'Product ' . $i, 'availability' => 'in_stock'];
+        }
+
+        $service = $this->createPreviewService($entities);
+
+        $result = $service->preview($this->feed(), new FeedContext(null, 'en_US', 'USD'), 2);
+
+        self::assertSame(2, $result->funnel->source, 'only the first $limit items per source are sampled');
+        self::assertSame(2, $result->funnel->included);
+        self::assertCount(2, $result->included);
     }
 
-    private function createGenerator(): FeedGenerator
+    /**
+     * @test
+     */
+    public function it_previews_a_single_included_item_by_id(): void
+    {
+        $service = $this->createPreviewService($this->catalog());
+
+        $verdict = $service->previewItem($this->feed(), new FeedContext(null, 'en_US', 'USD'), 'SKU-1');
+
+        self::assertTrue($verdict['included']);
+        self::assertNull($verdict['reason']);
+        self::assertSame('SKU-1', $verdict['output']['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_the_rule_that_drops_a_single_item(): void
+    {
+        $service = $this->createPreviewService($this->catalog());
+
+        $verdict = $service->previewItem($this->feed(), new FeedContext(null, 'en_US', 'USD'), 'SKU-2');
+
+        self::assertFalse($verdict['included']);
+        self::assertSame('filter:pre:availability', $verdict['reason']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_not_found_for_an_unknown_id(): void
+    {
+        $service = $this->createPreviewService($this->catalog());
+
+        $verdict = $service->previewItem($this->feed(), new FeedContext(null, 'en_US', 'USD'), 'DOES-NOT-EXIST');
+
+        self::assertFalse($verdict['included']);
+        self::assertSame('not_found', $verdict['reason']);
+        self::assertSame([], $verdict['output']);
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function catalog(): array
+    {
+        return [
+            (object) ['id' => 'SKU-1', 'title' => 'Shoe', 'availability' => 'in_stock'],
+            (object) ['id' => 'SKU-2', 'title' => 'Boot', 'availability' => 'out_of_stock'],
+            (object) ['id' => '', 'title' => 'Ghost', 'availability' => 'in_stock'],
+        ];
+    }
+
+    /**
+     * @param list<object> $entities
+     */
+    private function createPreviewService(array $entities): PreviewService
     {
         $feedTypeRegistry = $this->prophesize(FeedTypeRegistryInterface::class);
-        $feedTypeRegistry->get('product_variant')->willReturn($this->feedType());
+        $feedTypeRegistry->get('product_variant')->willReturn($this->feedType($entities));
 
         $presetRegistry = $this->prophesize(MappingPresetRegistryInterface::class);
 
         $formatRegistry = $this->prophesize(FormatRegistryInterface::class);
-        $formatRegistry->get('csv')->willReturn(new CsvFormat());
+        $formatRegistry->get('test_format')->willReturn($this->format());
 
-        $writerRegistry = $this->prophesize(FeedWriterRegistryInterface::class);
-        $writerRegistry->get('csv')->willReturn(new CsvWriter());
-
-        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
-        $urlGenerator->getContext()->willReturn(new RequestContext());
-
-        return new FeedGenerator(
+        return new PreviewService(
             $feedTypeRegistry->reveal(),
             new MappingResolver($presetRegistry->reveal()),
             $formatRegistry->reveal(),
-            $writerRegistry->reveal(),
             new FieldMappingEvaluator(
                 new TransformationChain(new TransformationRegistry([])),
                 new ReferenceResolver(),
-                new OperatorRegistry([new IsTrue()]),
+                new OperatorRegistry([new Equals(), new IsTrue()]),
                 new ExpressionEvaluator(new InMemoryLookup()),
                 new SandboxedTwigRenderer(new FeedTemplateSecurityPolicy(), new InMemoryLookup()),
                 new NullLookupReferenceResolver(),
@@ -141,19 +182,28 @@ final class FeedGeneratorFilterTest extends TestCase
             new NullLookupReferenceResolver(),
             new FeedItemValidator(Validation::createValidator(), new RequiredFieldsValidator()),
             new EventDispatcher(),
-            $urlGenerator->reveal(),
-            $this->filesystem,
         );
     }
 
-    private function feedType(): FeedTypeInterface
+    /**
+     * @param list<object> $entities
+     */
+    private function feedType(array $entities): FeedTypeInterface
     {
         $fields = [
             'id' => $this->field('id'),
+            'title' => $this->field('title'),
             'availability' => $this->field('availability'),
         ];
 
-        $dataSource = new class() implements DataSourceInterface {
+        $dataSource = new class($entities) implements DataSourceInterface {
+            /**
+             * @param list<object> $entities
+             */
+            public function __construct(private readonly array $entities)
+            {
+            }
+
             public function getResourceClass(): string
             {
                 return \stdClass::class;
@@ -161,13 +211,12 @@ final class FeedGeneratorFilterTest extends TestCase
 
             public function getItems(FeedContext $context, FilterSet $filters): iterable
             {
-                yield (object) ['id' => 'SKU-1', 'availability' => 'in_stock'];
-                yield (object) ['id' => 'SKU-2', 'availability' => 'out_of_stock'];
+                yield from $this->entities;
             }
 
             public function count(FeedContext $context, FilterSet $filters): int
             {
-                return 2;
+                return count($this->entities);
             }
         };
 
@@ -203,7 +252,7 @@ final class FeedGeneratorFilterTest extends TestCase
 
             public function getScopeDimensions(): array
             {
-                return [ScopeDimension::CHANNEL, ScopeDimension::LOCALE, ScopeDimension::CURRENCY];
+                return [];
             }
 
             public function getAvailableFields(): array
@@ -214,8 +263,8 @@ final class FeedGeneratorFilterTest extends TestCase
     }
 
     /**
-     * A field whose resolver reads the same-named property off the entity, so the two stub entities
-     * resolve to different availability values.
+     * A field whose resolver reads the same-named property off the entity, so each stub entity
+     * resolves to its own values.
      */
     private function field(string $name): FieldDefinition
     {
@@ -253,7 +302,37 @@ final class FeedGeneratorFilterTest extends TestCase
         return new FieldDefinition($name, $resolver->getLabel(), FieldType::STRING, $resolver);
     }
 
-    private function feed(string $stage): FeedInterface
+    private function format(): FormatInterface
+    {
+        return new class() implements FormatInterface {
+            public function getCode(): string
+            {
+                return 'test_format';
+            }
+
+            public function getWriter(): string
+            {
+                return 'csv';
+            }
+
+            public function getConfig(): WriterConfigInterface
+            {
+                return new CsvWriterConfig();
+            }
+
+            public function getRequiredFields(): array
+            {
+                return ['id'];
+            }
+
+            public function getItemValidationGroups(): array
+            {
+                return [];
+            }
+        };
+    }
+
+    private function feed(string $stage = FeedFilterInterface::STAGE_PRE): FeedInterface
     {
         $filter = new FeedFilter();
         $filter->setField('availability');
@@ -268,12 +347,13 @@ final class FeedGeneratorFilterTest extends TestCase
         $source->getFilters()->willReturn(new ArrayCollection([$filter]));
         $source->getFields()->willReturn(new ArrayCollection([
             $this->feedField('id', 'id', 0),
-            $this->feedField('availability', 'availability', 1),
+            $this->feedField('title', 'title', 1),
+            $this->feedField('availability', 'availability', 2),
         ]));
 
         $feed = $this->prophesize(FeedInterface::class);
         $feed->getCode()->willReturn('shop');
-        $feed->getFormat()->willReturn('csv');
+        $feed->getFormat()->willReturn('test_format');
         $feed->getSources()->willReturn(new ArrayCollection([$source->reveal()]));
 
         return $feed->reveal();

--- a/tests/Unit/Publish/GuardrailRegistryTest.php
+++ b/tests/Unit/Publish/GuardrailRegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Publish\GuardrailRegistry;
+use Setono\SyliusFeedPlugin\Publish\MinItemsGuardrail;
+use Setono\SyliusFeedPlugin\Publish\NonEmptyGuardrail;
+
+final class GuardrailRegistryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_keys_guardrails_by_their_type(): void
+    {
+        $minItems = new MinItemsGuardrail();
+        $nonEmpty = new NonEmptyGuardrail();
+
+        $registry = new GuardrailRegistry([$minItems, $nonEmpty]);
+
+        self::assertTrue($registry->has('min_items'));
+        self::assertTrue($registry->has('non_empty'));
+        self::assertFalse($registry->has('does_not_exist'));
+        self::assertSame($minItems, $registry->get('min_items'));
+        self::assertSame($nonEmpty, $registry->get('non_empty'));
+        self::assertCount(2, $registry);
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_duplicate_types(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new GuardrailRegistry([new NonEmptyGuardrail(), new NonEmptyGuardrail()]);
+    }
+}

--- a/tests/Unit/Publish/MaxDropPctGuardrailTest.php
+++ b/tests/Unit/Publish/MaxDropPctGuardrailTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\MaxDropPctGuardrail;
+
+final class MaxDropPctGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('max_drop_pct', (new MaxDropPctGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_without_a_baseline(): void
+    {
+        self::assertFalse((new MaxDropPctGuardrail())->evaluate($this->result(0), null, ['pct' => 40]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_drop_exceeds_the_threshold(): void
+    {
+        // 50_000 -> 5_000 is a 90% drop, well beyond the 40% threshold
+        self::assertTrue((new MaxDropPctGuardrail())->evaluate($this->result(5000), $this->result(50000), ['pct' => 40]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_drop_is_within_the_threshold(): void
+    {
+        // 100 -> 70 is a 30% drop, within a 40% threshold
+        self::assertFalse((new MaxDropPctGuardrail())->evaluate($this->result(70), $this->result(100), ['pct' => 40]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_candidate_grew_or_held_steady(): void
+    {
+        $guardrail = new MaxDropPctGuardrail();
+
+        self::assertFalse($guardrail->evaluate($this->result(120), $this->result(100), ['pct' => 40]));
+        self::assertFalse($guardrail->evaluate($this->result(100), $this->result(100), ['pct' => 40]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_baseline_was_empty(): void
+    {
+        self::assertFalse((new MaxDropPctGuardrail())->evaluate($this->result(0), $this->result(0), ['pct' => 40]));
+    }
+
+    private function result(int $itemCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/MaxExclusionPctGuardrailTest.php
+++ b/tests/Unit/Publish/MaxExclusionPctGuardrailTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\MaxExclusionPctGuardrail;
+
+final class MaxExclusionPctGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('max_exclusion_pct', (new MaxExclusionPctGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_on_the_absolute_threshold_without_a_baseline(): void
+    {
+        // 60 excluded of 100 processed = 60% exclusion, beyond the 50% threshold
+        self::assertTrue((new MaxExclusionPctGuardrail())->evaluate($this->result(40, 60), null, ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_ratio_is_within_the_threshold(): void
+    {
+        // 40 excluded of 100 = 40% exclusion, within the 50% threshold
+        self::assertFalse((new MaxExclusionPctGuardrail())->evaluate($this->result(60, 40), null, ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_ratio_did_not_jump_beyond_the_baseline(): void
+    {
+        // candidate 60% and baseline already 70% => a stable/lower exclusion share, not a regression
+        self::assertFalse(
+            (new MaxExclusionPctGuardrail())->evaluate($this->result(40, 60), $this->result(30, 70), ['pct' => 50]),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_ratio_exceeds_both_the_threshold_and_the_baseline(): void
+    {
+        // candidate 60% exclusion vs a baseline 20% exclusion => a real jump past the 50% threshold
+        self::assertTrue(
+            (new MaxExclusionPctGuardrail())->evaluate($this->result(40, 60), $this->result(80, 20), ['pct' => 50]),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_nothing_was_processed(): void
+    {
+        self::assertFalse((new MaxExclusionPctGuardrail())->evaluate($this->result(0, 0), null, ['pct' => 50]));
+    }
+
+    private function result(int $itemCount, int $excludedCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+        $result->setExcludedCount($excludedCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/MaxGrowthPctGuardrailTest.php
+++ b/tests/Unit/Publish/MaxGrowthPctGuardrailTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\MaxGrowthPctGuardrail;
+
+final class MaxGrowthPctGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('max_growth_pct', (new MaxGrowthPctGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_without_a_baseline(): void
+    {
+        self::assertFalse((new MaxGrowthPctGuardrail())->evaluate($this->result(1_000_000), null, ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_growth_exceeds_the_threshold(): void
+    {
+        // 100 -> 250 is 150% growth, beyond the 50% threshold
+        self::assertTrue((new MaxGrowthPctGuardrail())->evaluate($this->result(250), $this->result(100), ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_growth_is_within_the_threshold(): void
+    {
+        // 100 -> 140 is 40% growth, within a 50% threshold
+        self::assertFalse((new MaxGrowthPctGuardrail())->evaluate($this->result(140), $this->result(100), ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_candidate_shrank_or_held_steady(): void
+    {
+        $guardrail = new MaxGrowthPctGuardrail();
+
+        self::assertFalse($guardrail->evaluate($this->result(80), $this->result(100), ['pct' => 50]));
+        self::assertFalse($guardrail->evaluate($this->result(100), $this->result(100), ['pct' => 50]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_baseline_was_empty(): void
+    {
+        self::assertFalse((new MaxGrowthPctGuardrail())->evaluate($this->result(500), $this->result(0), ['pct' => 50]));
+    }
+
+    private function result(int $itemCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/MinBytesGuardrailTest.php
+++ b/tests/Unit/Publish/MinBytesGuardrailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\MinBytesGuardrail;
+
+final class MinBytesGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('min_bytes', (new MinBytesGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_file_is_smaller_than_the_minimum(): void
+    {
+        self::assertTrue((new MinBytesGuardrail())->evaluate($this->result(511), null, ['bytes' => 512]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_file_meets_the_minimum(): void
+    {
+        $guardrail = new MinBytesGuardrail();
+
+        self::assertFalse($guardrail->evaluate($this->result(512), null, ['bytes' => 512]));
+        self::assertFalse($guardrail->evaluate($this->result(1024), null, ['bytes' => 512]));
+    }
+
+    private function result(int $bytes): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setBytes($bytes);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/MinItemsGuardrailTest.php
+++ b/tests/Unit/Publish/MinItemsGuardrailTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\MinItemsGuardrail;
+
+final class MinItemsGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('min_items', (new MinItemsGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_item_count_is_below_the_minimum(): void
+    {
+        self::assertTrue((new MinItemsGuardrail())->evaluate($this->result(9), null, ['min' => 10]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_item_count_meets_the_minimum(): void
+    {
+        $guardrail = new MinItemsGuardrail();
+
+        self::assertFalse($guardrail->evaluate($this->result(10), null, ['min' => 10]));
+        self::assertFalse($guardrail->evaluate($this->result(11), null, ['min' => 10]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_the_baseline(): void
+    {
+        self::assertTrue((new MinItemsGuardrail())->evaluate($this->result(1), $this->result(1000), ['min' => 10]));
+    }
+
+    private function result(int $itemCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/NonEmptyGuardrailTest.php
+++ b/tests/Unit/Publish/NonEmptyGuardrailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\NonEmptyGuardrail;
+
+final class NonEmptyGuardrailTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_type(): void
+    {
+        self::assertSame('non_empty', (new NonEmptyGuardrail())->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_trips_when_the_candidate_is_empty(): void
+    {
+        self::assertTrue((new NonEmptyGuardrail())->evaluate($this->result(0), null, []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_trip_when_the_candidate_has_items(): void
+    {
+        $guardrail = new NonEmptyGuardrail();
+
+        self::assertFalse($guardrail->evaluate($this->result(1), null, []));
+        self::assertFalse($guardrail->evaluate($this->result(1), $this->result(0), []));
+    }
+
+    private function result(int $itemCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Publish/PublishGateTest.php
+++ b/tests/Unit/Publish/PublishGateTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Publish;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Model\FeedContextResult;
+use Setono\SyliusFeedPlugin\Publish\GuardrailRegistry;
+use Setono\SyliusFeedPlugin\Publish\MaxDropPctGuardrail;
+use Setono\SyliusFeedPlugin\Publish\MaxExclusionPctGuardrail;
+use Setono\SyliusFeedPlugin\Publish\MaxGrowthPctGuardrail;
+use Setono\SyliusFeedPlugin\Publish\MinBytesGuardrail;
+use Setono\SyliusFeedPlugin\Publish\MinItemsGuardrail;
+use Setono\SyliusFeedPlugin\Publish\NonEmptyGuardrail;
+use Setono\SyliusFeedPlugin\Publish\PublishGate;
+
+final class PublishGateTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_does_not_block_when_no_guardrails_are_configured(): void
+    {
+        $decision = $this->gate()->evaluate($this->result(0), null, []);
+
+        self::assertFalse($decision->blocked);
+        self::assertSame([], $decision->reasons);
+    }
+
+    /**
+     * @test
+     */
+    public function it_blocks_when_a_block_severity_guardrail_trips(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(0),
+            null,
+            [['type' => 'non_empty', 'severity' => 'block']],
+        );
+
+        self::assertTrue($decision->blocked);
+        self::assertCount(1, $decision->reasons);
+        self::assertStringContainsString('non_empty', $decision->reasons[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_records_a_reason_but_does_not_block_for_a_warn_guardrail(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(0),
+            null,
+            [['type' => 'non_empty', 'severity' => 'warn']],
+        );
+
+        self::assertFalse($decision->blocked);
+        self::assertCount(1, $decision->reasons);
+        self::assertStringContainsString('warn', $decision->reasons[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_unknown_guardrail_types(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(0),
+            null,
+            [['type' => 'does_not_exist', 'severity' => 'block']],
+        );
+
+        self::assertFalse($decision->blocked);
+        self::assertSame([], $decision->reasons);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_record_a_reason_for_a_guardrail_that_does_not_trip(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(100),
+            null,
+            [['type' => 'non_empty', 'severity' => 'block']],
+        );
+
+        self::assertFalse($decision->blocked);
+        self::assertSame([], $decision->reasons);
+    }
+
+    /**
+     * @test
+     */
+    public function it_blocks_when_any_block_guardrail_trips_among_several(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(0),
+            null,
+            [
+                ['type' => 'min_bytes', 'params' => ['bytes' => 10], 'severity' => 'warn'],
+                ['type' => 'non_empty', 'severity' => 'block'],
+            ],
+        );
+
+        self::assertTrue($decision->blocked);
+        self::assertCount(2, $decision->reasons);
+    }
+
+    /**
+     * @test
+     */
+    public function it_defaults_missing_severity_to_block(): void
+    {
+        $decision = $this->gate()->evaluate(
+            $this->result(0),
+            null,
+            [['type' => 'non_empty']],
+        );
+
+        self::assertTrue($decision->blocked);
+    }
+
+    /**
+     * @test
+     */
+    public function it_blocks_the_50k_to_5k_collapse(): void
+    {
+        // Acceptance (§6.6): a candidate of 5000 items vs a baseline of 50000, with a
+        // max_drop_pct guardrail set to 40% and block severity, must block promotion.
+        $decision = $this->gate()->evaluate(
+            $this->result(5000),
+            $this->result(50000),
+            [['type' => 'max_drop_pct', 'params' => ['pct' => 40], 'severity' => 'block']],
+        );
+
+        self::assertTrue($decision->blocked);
+        self::assertCount(1, $decision->reasons);
+        self::assertStringContainsString('max_drop_pct', $decision->reasons[0]);
+    }
+
+    private function gate(): PublishGate
+    {
+        return new PublishGate(new GuardrailRegistry([
+            new MinItemsGuardrail(),
+            new MaxDropPctGuardrail(),
+            new NonEmptyGuardrail(),
+            new MinBytesGuardrail(),
+            new MaxExclusionPctGuardrail(),
+            new MaxGrowthPctGuardrail(),
+        ]));
+    }
+
+    private function result(int $itemCount): FeedContextResult
+    {
+        $result = new FeedContextResult();
+        $result->setItemCount($itemCount);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Validator/FeedItemValidatorTest.php
+++ b/tests/Unit/Validator/FeedItemValidatorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFeedPlugin\Tests\Unit\Validator;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusFeedPlugin\Context\FeedContext;
+use Setono\SyliusFeedPlugin\Item\FeedItem;
+use Setono\SyliusFeedPlugin\Item\Google\Availability;
+use Setono\SyliusFeedPlugin\Item\Google\GoogleShoppingItem;
+use Setono\SyliusFeedPlugin\Validator\FeedItemValidator;
+use Setono\SyliusFeedPlugin\Validator\RequiredFieldsValidator;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Proves the typed-item validation of §11: a GoogleShoppingItem runs the Google Shopping constraint
+ * mapping (missing required fields / over-long title produce violation messages), while a plain
+ * FeedItem carries no constraints and only the generic required-field fallback fires.
+ */
+final class FeedItemValidatorTest extends TestCase
+{
+    private function feedItemValidator(): FeedItemValidator
+    {
+        return new FeedItemValidator($this->symfonyValidator(), new RequiredFieldsValidator());
+    }
+
+    private function symfonyValidator(): ValidatorInterface
+    {
+        return Validation::createValidatorBuilder()
+            ->addXmlMapping(__DIR__ . '/../../../src/Resources/config/validation/GoogleShoppingItem.xml')
+            ->getValidator()
+        ;
+    }
+
+    private function context(): FeedContext
+    {
+        return new FeedContext(null, 'en_US', 'USD');
+    }
+
+    private function validGoogleShoppingItem(): GoogleShoppingItem
+    {
+        $item = new GoogleShoppingItem(new \stdClass(), $this->context());
+        $item->setId('SKU-1');
+        $item->setTitle('Acme Shoe');
+        $item->setDescription('Very nice');
+        $item->setLink('https://example.com/products/acme-shoe');
+        $item->setImageLink('https://example.com/img/main.jpg');
+        $item->setAvailability(Availability::IN_STOCK);
+        $item->setPrice('9.99 USD');
+
+        return $item;
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_a_google_shopping_item_missing_its_title(): void
+    {
+        $item = $this->validGoogleShoppingItem();
+        $item->remove(GoogleShoppingItem::TITLE);
+
+        $messages = $this->feedItemValidator()->validate($item, []);
+
+        self::assertContains('setono_sylius_feed.google_shopping_item.title.not_blank', $messages);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_a_google_shopping_item_with_a_too_long_title(): void
+    {
+        $item = $this->validGoogleShoppingItem();
+        $item->setTitle(str_repeat('a', 151));
+
+        $messages = $this->feedItemValidator()->validate($item, []);
+
+        self::assertContains('setono_sylius_feed.google_shopping_item.title.max_length', $messages);
+    }
+
+    /**
+     * @test
+     */
+    public function it_considers_a_fully_populated_google_shopping_item_valid(): void
+    {
+        self::assertSame([], $this->feedItemValidator()->validate($this->validGoogleShoppingItem(), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_a_missing_required_field_on_a_plain_feed_item_via_the_fallback(): void
+    {
+        $item = new FeedItem(new \stdClass(), $this->context());
+        $item->set('g:id', 'SKU-1');
+
+        $messages = $this->feedItemValidator()->validate($item, ['g:id', 'g:title']);
+
+        self::assertSame(['setono_sylius_feed.validation.missing_field: g:title'], $messages);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_the_typed_constraints_when_the_format_opts_out(): void
+    {
+        // an empty validation-group list (a non-Google format) must not run the g:* constraints,
+        // even though the item is a GoogleShoppingItem lacking every field
+        $item = new GoogleShoppingItem(new \stdClass(), $this->context());
+
+        self::assertSame([], $this->feedItemValidator()->validate($item, [], []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_still_runs_the_required_field_fallback_when_the_typed_constraints_are_skipped(): void
+    {
+        $item = new GoogleShoppingItem(new \stdClass(), $this->context());
+
+        self::assertSame(
+            ['setono_sylius_feed.validation.missing_field: g:id'],
+            $this->feedItemValidator()->validate($item, ['g:id'], []),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_deduplicates_messages(): void
+    {
+        $item = $this->validGoogleShoppingItem();
+        $item->remove(GoogleShoppingItem::TITLE);
+
+        // both the typed NotBlank constraint and the required-field fallback flag g:title, but the
+        // fallback message key differs, so the two are distinct; the typed message appears once
+        $messages = $this->feedItemValidator()->validate($item, ['g:title']);
+
+        self::assertSame(
+            $messages,
+            array_values(array_unique($messages)),
+            'The returned messages must be deduplicated',
+        );
+    }
+}


### PR DESCRIPTION
## M6 — Filtering, validation, reporting, preview, publish gate (§11, §6.6)

Four chunks; **581 tests**; the Preview admin screen is browser-verified.

### Filtering
- `FilterEvaluator` resolves a `FeedFilter`'s field/value via the reference rule + the shared
  operator vocabulary; `exclude` drops on match, `include` drops on non-match. Wired into the
  generator: **pre** filters run before mapping, **post** filters on the mapped output. Excluded
  items are counted and reported. `SourceResolverBinder` binds the item's source resolver once
  (before pre-filters). **exclude-out-of-stock works.**

### Validation + reporting
- `FeedType::createItem()` lets a type provide a typed `FeedItem` (`product_variant` →
  `GoogleShoppingItem`). Symfony constraints on `GoogleShoppingItem` (required `g:` fields, title
  ≤150), applied **format-scoped** (RSS runs them; CSV/others fall back to the required-field list).
- `FeedContextResult` resource records per-context `itemCount/excludedCount/bytes` + every exclusion
  with its reason (`filter:{stage}:{field}` / `validation:{msg}` / `skipped`), recorded at finalize.

### Publish gate + guardrails
- `Feed.publishConfig` guardrails (`min_items`, `max_drop_pct`, `non_empty`, `min_bytes`,
  `max_exclusion_pct`, `max_growth_pct`) compare the candidate vs the last-good `FeedContextResult`
  baseline; `PublishGate` blocks on a tripped `block`-severity guardrail, warns otherwise.
- **Finalize is now per-context + gated:** `GenerateFeedContextHandler` runs the gate after
  recording (stamps `publishState`, dispatches `FeedPublishBlockedEvent`); `MoveGeneratedFeedSubscriber`
  no longer wipes canonical — it promotes only **published** contexts and **retains blocked**
  candidates in staging. A **publish-anyway** admin action promotes a retained candidate.
- **Acceptance:** a 5k-vs-50k regenerate trips `max_drop_pct` → blocked, the live file is retained,
  the event fires.

### Preview + audit
- Shared `MappingResolver` (FeedField-first, preset fallback) reused by the generator and preview.
- `PreviewService` runs the exact per-item pipeline over ≤N sampled items, writing nothing, returning
  a **funnel** (source → after-pre → after-mapping/validation → after-post → included), included
  sample bags, excluded samples with reasons, and a single-item tester.
- `FeedAuditService` reports per-field fill rates, soft warnings (title>150, HTML-in-description,
  price=0) and value distributions — advisory only.
- Admin **Preview** screen (`/feeds/{id}/preview` + grid action) and console `--preview[=N]` / `--audit`.

### CI note
Verified locally against the updated PHPStan/Rector/ECS **and** PHP-8.1-pinned PHPStan + league/csv
9.6, so the gate (Unit / Integration / Static Code Analysis / Coding Standards) should be green. BC,
Dependency Analysis and Mutation remain the standing rewrite reds.
