### PR TITLE
Admin: a friendlier, segmented feed form

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -8,6 +8,8 @@ setono_sylius_feed_admin_feed:
         vars:
             all:
                 subheader: setono_sylius_feed.ui.manage_feeds
+                templates:
+                    form: "@SetonoSyliusFeedPlugin/admin/feed/_form.html.twig"
             index:
                 icon: rss
     type: sylius.resource

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -6,6 +6,11 @@ setono_sylius_feed:
         edit_lookup_table: Edit lookup table
         manage_feeds: Manage feeds
         manage_lookup_tables: Manage lookup tables
+        details: Details
+        output: Output
+        translations: Name & slug
+        sources_help: Where the feed's items come from, and how each output field is mapped, transformed and filtered.
+        delivery_targets_help: 'Optionally push each generated file to remote destinations (FTP/SFTP/S3) after it is published.'
         refresh: Refresh
         refreshed_at: Refreshed at
         new_feed: New feed

--- a/src/Resources/views/admin/feed/_form.html.twig
+++ b/src/Resources/views/admin/feed/_form.html.twig
@@ -1,0 +1,47 @@
+{% from '@SyliusAdmin/Macro/translationForm.html.twig' import translationForm %}
+
+{{ form_errors(form) }}
+
+<div class="ui two column stackable grid">
+    <div class="column">
+        <div class="ui fluid segment">
+            <h4 class="ui dividing header">{{ 'setono_sylius_feed.ui.details'|trans }}</h4>
+
+            {{ form_row(form.code) }}
+            {{ form_row(form.enabled) }}
+
+            <h5 class="ui top attached header">{{ 'setono_sylius_feed.ui.translations'|trans }}</h5>
+            <div class="ui attached segment">
+                {{ translationForm(form.translations) }}
+            </div>
+        </div>
+    </div>
+
+    <div class="column">
+        <div class="ui fluid segment">
+            <h4 class="ui dividing header">{{ 'setono_sylius_feed.ui.output'|trans }}</h4>
+
+            {{ form_row(form.target) }}
+            {{ form_row(form.format) }}
+            {{ form_row(form.channels) }}
+        </div>
+    </div>
+</div>
+
+<div class="ui segment">
+    <h4 class="ui dividing header">
+        {{ 'setono_sylius_feed.form.feed.sources'|trans }}
+        <div class="sub header">{{ 'setono_sylius_feed.ui.sources_help'|trans }}</div>
+    </h4>
+    {{ form_widget(form.sources) }}
+    {{ form_errors(form.sources) }}
+</div>
+
+<div class="ui segment">
+    <h4 class="ui dividing header">
+        {{ 'setono_sylius_feed.form.feed.delivery_targets'|trans }}
+        <div class="sub header">{{ 'setono_sylius_feed.ui.delivery_targets_help'|trans }}</div>
+    </h4>
+    {{ form_widget(form.deliveryTargets) }}
+    {{ form_errors(form.deliveryTargets) }}
+</div>


### PR DESCRIPTION
The feed create/edit form was a flat stack of fields. This points the resource's `vars.templates.form` at a custom `_form.html.twig` that:

- groups fields into **Semantic UI segments** with dividing section headers — **Details** (code, enabled, name/slug), **Output** (target, format, channels), **Sources**, **Delivery targets** — in a two-column stackable grid for the compact fields and full width for the wide collections;
- renders the name/slug translations through Sylius' **`translationForm` macro** (the per-locale accordion) instead of a flat list;
- adds explanatory sub-headers under the Sources and Delivery targets sections.

Browser-verified against the running test app: the page renders, the translations accordion (8 locales) and all four collection add buttons work, and the form still submits and persists. No PHP changed.